### PR TITLE
[PREVIEW] Using white-space pre-wrap to retain line breaks in question body

### DIFF
--- a/app/assets/sass/_question.scss
+++ b/app/assets/sass/_question.scss
@@ -11,3 +11,7 @@
     border: none;
   }
 }
+
+#question-body {
+  white-space: pre-wrap;
+}

--- a/app/views/includes/sending-evidence.html
+++ b/app/views/includes/sending-evidence.html
@@ -1,19 +1,22 @@
 {% set reference = "SC242/16/03435" %}
 
-<details id="sending-evidence-guide" class="govuk-details">
-    <summary class="govuk-details__summary">
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <details id="sending-evidence-guide" class="govuk-details">
+            <summary class="govuk-details__summary">
         <span class="govuk-details__summary-text">
           {{ i18n.guidance.sendingEvidence.summary }}
         </span>
-    </summary>
-    <div class="govuk-details__text">
-        <p>{{ i18n.guidance.sendingEvidence.details.para1 }}</p>
-        <p>{{ i18n.guidance.sendingEvidence.details.para2 }}<br><strong>{{ reference }}</strong></p>
-        <h3 class="govuk-heading-s">{{ i18n.guidance.sendingEvidence.details.byEmailHeader }}</h3>
-        <p><a href="mailto:{{ i18n.guidance.sendingEvidence.details.emailAddress }}?subject=Evidence:%20{{ reference }}">{{ i18n.guidance.sendingEvidence.details.emailAddress }}</a></p>
-        <h3 class="govuk-heading-s">{{ i18n.guidance.sendingEvidence.details.byPostHeader}}</h3>
-        <p>{{ i18n.guidance.sendingEvidence.details.postalAddress | safe }}</p>
-        <p>{{ i18n.guidance.sendingEvidence.details.closingPara }}</p>
+            </summary>
+            <div class="govuk-details__text">
+                <p>{{ i18n.guidance.sendingEvidence.details.para1 }}</p>
+                <p>{{ i18n.guidance.sendingEvidence.details.para2 }}<br><strong>{{ reference }}</strong></p>
+                <h3 class="govuk-heading-s">{{ i18n.guidance.sendingEvidence.details.byEmailHeader }}</h3>
+                <p><a href="mailto:{{ i18n.guidance.sendingEvidence.details.emailAddress }}?subject=Evidence:%20{{ reference }}">{{ i18n.guidance.sendingEvidence.details.emailAddress }}</a></p>
+                <h3 class="govuk-heading-s">{{ i18n.guidance.sendingEvidence.details.byPostHeader}}</h3>
+                <p>{{ i18n.guidance.sendingEvidence.details.postalAddress | safe }}</p>
+                <p>{{ i18n.guidance.sendingEvidence.details.closingPara }}</p>
+            </div>
+        </details>
     </div>
-</details>
-
+</div>

--- a/app/views/question.html
+++ b/app/views/question.html
@@ -9,9 +9,9 @@
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-l">{{ question.header }}</h1>
+            <h1 class="govuk-heading-l question-header">{{ question.header }}</h1>
             <div>
-                <p>{{ question.body }}</p>
+                <p id="question-body">{{ question.body }}</p>
                 {{ govukTextarea({
                     id: 'question-field',
                     label: {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "yarn test:unit && yarn test:browser",
     "test:unit": "cross-env NODE_PATH=. NODE_ENV=test mocha test/unit --recursive",
     "test:browser": "cross-env NODE_PATH=. NODE_ENV=test mocha test/browser --recursive --timeout=10000",
-    "test:functional": "yarn test:browser",
+    "test:functional": "yarn test:browser -g @smoke --invert",
     "test:smoke": "yarn test:browser -g @smoke",
     "test:coverage": "cross-env NODE_PATH=. istanbul cover _mocha test/unit/** --dir test/coverage/html",
     "test:a11y": "cross-env NODE_PATH=. LOG_LEVEL=OFF mocha test/accessibility --recursive --timeout=10000",

--- a/test/mock/data/question.js
+++ b/test/mock/data/question.js
@@ -1,10 +1,9 @@
+/* eslint-disable max-len */
 module.exports = {
   path: '/continuous-online-hearings/:onlineHearingId/questions/:questionId',
   template: {
     question_id: params => `${params.questionId}`,
     question_header_text: 'How do you interact with people?',
-    question_body_text: `You said you avoid interacting with people if possible. We’d like to know 
-      more about the times when you see friends and family. Tell us about three separate occasions 
-      in 2017 that you have met with friends and family.`
+    question_body_text: 'You said you avoid interacting with people if possible. We\'d like to know more about the times when you see friends and family.\n\nTell us about three separate occasions in 2017 that you have met with friends and family.\n\nTell us:\n\n- who you met\n\n- when\n\n- where\n\n- how it made you feel'
   }
 };


### PR DESCRIPTION
* assuming that line-breaks are returned from the API as `\n`
* adding line breaks to mock data that is also used for creating a real question in functional testing
* applying two-thirds grid layout to sending evidence content