### PR TITLE
[PREVIEW] SSCS-3554 show appellant name and SC reference

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,7 @@
     "max-len": [
       "error",
       {
-        "code": 100
+        "code": 120
       }
     ]
   }

--- a/app/assets/sass/_task-list.scss
+++ b/app/assets/sass/_task-list.scss
@@ -1,4 +1,5 @@
 #task-list {
+  margin-top: 40px;
   li {
     border-bottom: 1px solid $govuk-border-colour;
     padding: 10px 0;
@@ -12,8 +13,14 @@
       float: right;
 
       &.draft {
-        background-color: #6f777b;
+        background-color: govuk-colour("grey-1");
       }
     }
+  }
+}
+
+#appeal-details {
+  h2 {
+    margin-bottom: 0;
   }
 }

--- a/app/assets/sass/_task-list.scss
+++ b/app/assets/sass/_task-list.scss
@@ -23,4 +23,8 @@
   h2 {
     margin-bottom: 0;
   }
+  #logout {
+    font-weight: $govuk-font-weight-regular;
+    font-size: 19px;
+  }
 }

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -4,3 +4,7 @@ $govuk-assets-path: '/public/govuk-frontend/';
 @import "node_modules/govuk-frontend/all";
 @import "_question";
 @import "_task-list";
+
+.divider {
+  border-bottom: 3px solid govuk-colour("blue");
+}

--- a/app/controllers/login.js
+++ b/app/controllers/login.js
@@ -2,6 +2,7 @@ const { Logger } = require('@hmcts/nodejs-logging');
 const appInsights = require('app-insights');
 const express = require('express');
 const paths = require('paths');
+const { loginEmailAddressValidation } = require('app/utils/fieldValidation');
 
 const logger = Logger.getLogger('login.js');
 
@@ -23,8 +24,13 @@ function getLogout(req, res) {
 function postLogin(getOnlineHearingService) {
   return async(req, res, next) => {
     const email = req.body['email-address'];
-    if (!email) {
-      return res.redirect(paths.login);
+    const validationMessage = loginEmailAddressValidation(email);
+    if (validationMessage) {
+      const emailAddress = {
+        value: email,
+        error: validationMessage
+      };
+      return res.render('login.html', { emailAddress });
     }
     try {
       const hearing = await getOnlineHearingService(email);

--- a/app/controllers/login.js
+++ b/app/controllers/login.js
@@ -1,0 +1,42 @@
+const { Logger } = require('@hmcts/nodejs-logging');
+const appInsights = require('app-insights');
+const express = require('express');
+const paths = require('paths');
+
+const logger = Logger.getLogger('login.js');
+
+function getLogin(req, res) {
+  return res.render('login.html');
+}
+
+function postLogin(getOnlineHearingService) {
+  return async(req, res, next) => {
+    const email = req.body['email-address'];
+    if (!email) {
+      return res.redirect(paths.login);
+    }
+    try {
+      const hearing = await getOnlineHearingService(email);
+      req.session.hearing = hearing;
+      logger.info(`Logging in ${email}`);
+      return res.redirect(paths.taskList);
+    } catch (error) {
+      appInsights.trackException(error);
+      return next(error);
+    }
+  };
+}
+
+function setupLoginController(deps) {
+  // eslint-disable-next-line new-cap
+  const router = express.Router();
+  router.get(paths.login, getLogin);
+  router.post(paths.login, postLogin(deps.getOnlineHearingService));
+  return router;
+}
+
+module.exports = {
+  setupLoginController,
+  getLogin,
+  postLogin
+};

--- a/app/controllers/login.js
+++ b/app/controllers/login.js
@@ -1,7 +1,7 @@
 const { Logger } = require('@hmcts/nodejs-logging');
 const appInsights = require('app-insights');
 const express = require('express');
-const { NOT_FOUND } = require('http-status-codes');
+const { NOT_FOUND, UNPROCESSABLE_ENTITY } = require('http-status-codes');
 const paths = require('paths');
 const i18n = require('app/locale/en.json');
 const { loginEmailAddressValidation } = require('app/utils/fieldValidation');
@@ -36,11 +36,11 @@ function postLogin(getOnlineHearingService) {
     }
     try {
       const response = await getOnlineHearingService(email);
-      if (response.status === NOT_FOUND) {
-        logger.info(`Online hearing not found for ${email}`);
+      if (response.status === NOT_FOUND || response.status === UNPROCESSABLE_ENTITY) {
+        logger.info(`Know issue trying to find hearing for ${email}, status ${response.status}`);
         const emailAddress = {
           value: email,
-          error: i18n.login.emailAddress.error.notFound
+          error: i18n.login.emailAddress.error[`error${response.status}`]
         };
         return res.render('login.html', { emailAddress });
       }

--- a/app/controllers/login.js
+++ b/app/controllers/login.js
@@ -9,6 +9,17 @@ function getLogin(req, res) {
   return res.render('login.html');
 }
 
+function getLogout(req, res) {
+  const sessionId = req.session.id;
+  req.session.destroy(error => {
+    if (error) {
+      logger.error(`Error destroying session ${sessionId}`);
+    }
+    logger.info(`Session destroyed ${sessionId}`);
+    return res.redirect(paths.login);
+  });
+}
+
 function postLogin(getOnlineHearingService) {
   return async(req, res, next) => {
     const email = req.body['email-address'];
@@ -31,6 +42,7 @@ function setupLoginController(deps) {
   // eslint-disable-next-line new-cap
   const router = express.Router();
   router.get(paths.login, getLogin);
+  router.get(paths.logout, getLogout);
   router.post(paths.login, postLogin(deps.getOnlineHearingService));
   return router;
 }
@@ -38,5 +50,6 @@ function setupLoginController(deps) {
 module.exports = {
   setupLoginController,
   getLogin,
+  getLogout,
   postLogin
 };

--- a/app/controllers/question.js
+++ b/app/controllers/question.js
@@ -58,8 +58,8 @@ function postAnswer(postAnswerService) {
 function setupQuestionController(deps) {
   // eslint-disable-next-line new-cap
   const router = express.Router();
-  router.get('/:hearingId/:questionId', deps.ensureAuthenticated, getQuestion(deps.getQuestionService));
-  router.post('/:hearingId/:questionId', deps.ensureAuthenticated, postAnswer(deps.postAnswerService));
+  router.get('/:hearingId/:questionId', getQuestion(deps.getQuestionService));
+  router.post('/:hearingId/:questionId', postAnswer(deps.postAnswerService));
   return router;
 }
 

--- a/app/controllers/question.js
+++ b/app/controllers/question.js
@@ -58,8 +58,8 @@ function postAnswer(postAnswerService) {
 function setupQuestionController(deps) {
   // eslint-disable-next-line new-cap
   const router = express.Router();
-  router.get('/:hearingId/:questionId', getQuestion(deps.getQuestionService));
-  router.post('/:hearingId/:questionId', postAnswer(deps.postAnswerService));
+  router.get('/:hearingId/:questionId', deps.ensureAuthenticated, getQuestion(deps.getQuestionService));
+  router.post('/:hearingId/:questionId', deps.ensureAuthenticated, postAnswer(deps.postAnswerService));
   return router;
 }
 

--- a/app/controllers/taskList.js
+++ b/app/controllers/taskList.js
@@ -1,12 +1,13 @@
 const appInsights = require('app-insights');
 const express = require('express');
+const paths = require('paths');
 
 function getTaskList(getAllQuestionsService) {
   return async(req, res, next) => {
-    const hearingId = req.params.hearingId;
+    const hearing = req.session.hearing;
     try {
-      const questions = await getAllQuestionsService(hearingId);
-      res.render('task-list.html', Object.assign({ hearingId }, questions));
+      const questions = await getAllQuestionsService(hearing.online_hearing_id);
+      res.render('task-list.html', questions);
     } catch (error) {
       appInsights.trackException(error);
       next(error);
@@ -17,7 +18,7 @@ function getTaskList(getAllQuestionsService) {
 function setupTaskListController(deps) {
   // eslint-disable-next-line new-cap
   const router = express.Router();
-  router.get('/:hearingId', getTaskList(deps.getAllQuestionsService));
+  router.get(paths.taskList, deps.ensureAuthenticated, getTaskList(deps.getAllQuestionsService));
   return router;
 }
 

--- a/app/controllers/taskList.js
+++ b/app/controllers/taskList.js
@@ -5,9 +5,10 @@ const paths = require('paths');
 function getTaskList(getAllQuestionsService) {
   return async(req, res, next) => {
     const hearing = req.session.hearing;
+    const hearingId = (hearing && hearing.online_hearing_id) || req.params.hearingId;
     try {
-      const questions = await getAllQuestionsService(hearing.online_hearing_id);
-      res.render('task-list.html', questions);
+      const questions = await getAllQuestionsService(hearingId);
+      res.render('task-list.html', { hearingId, ...questions });
     } catch (error) {
       appInsights.trackException(error);
       next(error);
@@ -19,6 +20,7 @@ function setupTaskListController(deps) {
   // eslint-disable-next-line new-cap
   const router = express.Router();
   router.get(paths.taskList, deps.ensureAuthenticated, getTaskList(deps.getAllQuestionsService));
+  router.get(`${paths.taskList}/:hearingId`, getTaskList(deps.getAllQuestionsService));
   return router;
 }
 

--- a/app/locale/en.json
+++ b/app/locale/en.json
@@ -21,7 +21,14 @@
     }
   },
   "login": {
-    "header": "Login"
+    "header": "Login",
+    "emailAddress": {
+      "error": {
+        "summaryHeading": "There is a problem",
+        "empty": "Enter your email address",
+        "format": "Enter a valid email address"
+      }
+    }
   },
   "taskList": {
     "header": "Task list",

--- a/app/locale/en.json
+++ b/app/locale/en.json
@@ -27,7 +27,8 @@
         "summaryHeading": "There is a problem",
         "empty": "Enter your email address",
         "format": "Enter a valid email address",
-        "notFound": "Online hearing could not be found"
+        "error404": "Online hearing could not be found",
+        "error422": "Multiple online hearings found"
       }
     }
   },

--- a/app/locale/en.json
+++ b/app/locale/en.json
@@ -6,9 +6,6 @@
     "feedback": "feedback",
     "improve": "will help us to improve it."
   },
-  "helloWorld": {
-    "header": "Hello world"
-  },
   "guidance": {
     "sendingEvidence": {
       "summary": "Sending evidence to support your answer",
@@ -22,6 +19,9 @@
         "closingPara": "Useful evidence helps prove what you have said in your answer such as a letter from a doctor or someone who knows you well. You do not have to send in evidence if you don’t have any."
       }
     }
+  },
+  "login": {
+    "header": "Login"
   },
   "taskList": {
     "header": "Task list",

--- a/app/locale/en.json
+++ b/app/locale/en.json
@@ -26,7 +26,8 @@
       "error": {
         "summaryHeading": "There is a problem",
         "empty": "Enter your email address",
-        "format": "Enter a valid email address"
+        "format": "Enter a valid email address",
+        "notFound": "Online hearing could not be found"
       }
     }
   },

--- a/app/middleware/ensure-authenticated.js
+++ b/app/middleware/ensure-authenticated.js
@@ -1,0 +1,31 @@
+const { Logger } = require('@hmcts/nodejs-logging');
+const paths = require('paths');
+
+const logger = Logger.getLogger('ensure-authenticated.js');
+
+/* eslint-disable-next-line consistent-return */
+function verifyOnlineHearingId(req, res, next) {
+  const hearingId = req.session.hearing && req.session.hearing.online_hearing_id;
+  if (hearingId) {
+    return next();
+  }
+  const sessionId = req.session.id;
+  req.session.destroy(error => {
+    if (error) {
+      logger.error(`Error destroying session ${sessionId}`);
+    }
+    logger.info(`Session destroyed ${sessionId}`);
+    return res.redirect(paths.login);
+  });
+}
+
+function setLocals(req, res, next) {
+  res.locals.hearing = req.session.hearing;
+  next();
+}
+
+module.exports = {
+  verifyOnlineHearingId,
+  setLocals,
+  ensureAuthenticated: [verifyOnlineHearingId, setLocals]
+};

--- a/app/routes.js
+++ b/app/routes.js
@@ -1,8 +1,10 @@
 const express = require('express');
 const paths = require('paths');
+const { ensureAuthenticated } = require('app/middleware/ensure-authenticated');
 
 const { setupQuestionController } = require('app/controllers/question');
 const { setupTaskListController } = require('app/controllers/taskList');
+const { setupLoginController } = require('app/controllers/login');
 
 // eslint-disable-next-line new-cap
 const router = express.Router();
@@ -10,12 +12,18 @@ const router = express.Router();
 const getQuestionService = require('app/services/getQuestion');
 const postAnswerService = require('app/services/postAnswer');
 const getAllQuestionsService = require('app/services/getAllQuestions');
+const getOnlineHearingService = require('app/services/getOnlineHearing');
 
-const questionController = setupQuestionController({ getQuestionService, postAnswerService });
+const questionController = setupQuestionController({
+  getQuestionService,
+  postAnswerService,
+  ensureAuthenticated
+});
+const taskListController = setupTaskListController({ getAllQuestionsService, ensureAuthenticated });
+const loginController = setupLoginController({ getOnlineHearingService });
 
-const taskListController = setupTaskListController({ getAllQuestionsService });
-
+router.use(loginController);
 router.use(paths.question, questionController);
-router.use(paths.taskList, taskListController);
+router.use(taskListController);
 
 module.exports = router;

--- a/app/services/getOnlineHearing.js
+++ b/app/services/getOnlineHearing.js
@@ -1,0 +1,17 @@
+const config = require('config');
+const request = require('superagent');
+
+const apiUrl = config.get('api.url');
+
+async function getOnlineHearing(email) {
+  try {
+    const response = await request
+      .get(`${apiUrl}/continuous-online-hearings`)
+      .query({ email });
+    return Promise.resolve(response.body);
+  } catch (error) {
+    return Promise.reject(error);
+  }
+}
+
+module.exports = getOnlineHearing;

--- a/app/services/getOnlineHearing.js
+++ b/app/services/getOnlineHearing.js
@@ -1,5 +1,6 @@
 const config = require('config');
 const request = require('superagent');
+const { INTERNAL_SERVER_ERROR } = require('http-status-codes');
 
 const apiUrl = config.get('api.url');
 
@@ -7,8 +8,9 @@ async function getOnlineHearing(email) {
   try {
     const response = await request
       .get(`${apiUrl}/continuous-online-hearings`)
-      .query({ email });
-    return Promise.resolve(response.body);
+      .query({ email })
+      .ok(res => res.status < INTERNAL_SERVER_ERROR);
+    return Promise.resolve(response);
   } catch (error) {
     return Promise.reject(error);
   }

--- a/app/utils/fieldValidation.js
+++ b/app/utils/fieldValidation.js
@@ -24,6 +24,25 @@ function answerValidation(answer) {
   return error;
 }
 
+function loginEmailAddressValidation(email) {
+  const schema = Joi.string()
+    .required()
+    .email({ minDomainAtoms: 2 })
+    .options({
+      language: {
+        any: { empty: `!!${i18n.login.emailAddress.error.empty}` },
+        string: { email: `!!${i18n.login.emailAddress.error.format}` }
+      }
+    });
+  const result = schema.validate(email);
+  let error = false;
+  if (result.error) {
+    error = result.error.details[0].message;
+  }
+  return error;
+}
+
 module.exports = {
-  answerValidation
+  answerValidation,
+  loginEmailAddressValidation
 };

--- a/app/views/login.html
+++ b/app/views/login.html
@@ -1,9 +1,20 @@
 {% extends "layout.html" %}
 {% from "input/macro.njk" import govukInput %}
+{% from "components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
+
+            {% if emailAddress.error %}
+                {{ govukErrorSummary({
+                    titleText: i18n.login.emailAddress.error.summaryHeading,
+                    errorList: [{
+                        text: emailAddress.error,
+                        href: "#email-address"
+                    }]
+                }) }}
+            {% endif %}
 
             <h1 class="govuk-heading-l">{{ i18n.login.header }}</h1>
 
@@ -13,12 +24,13 @@
                         "label": {
                             "text": "Email address"
                         },
+                        "value": emailAddress.value,
                         "id": "email-address",
                         "name": "email-address",
                         "classes": "govuk-input--width-20",
-                        "attributes": {
-                            "required": "true"
-                        }
+                        "errorMessage": {
+                            "text": emailAddress.error
+                        } if emailAddress.error
                     }) }}
                 </div>
                 <div id="submit-buttons">

--- a/app/views/login.html
+++ b/app/views/login.html
@@ -1,0 +1,30 @@
+{% extends "layout.html" %}
+{% from "input/macro.njk" import govukInput %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+
+            <h1 class="govuk-heading-l">{{ i18n.login.header }}</h1>
+
+            <form action="/login" method="post">
+                <div>
+                    {{ govukInput({
+                        "label": {
+                            "text": "Email address"
+                        },
+                        "id": "email-address",
+                        "name": "email-address",
+                        "classes": "govuk-input--width-20",
+                        "attributes": {
+                            "required": "true"
+                        }
+                    }) }}
+                </div>
+                <div id="submit-buttons">
+                    <input id="login" type="submit" name="submit" value="Login" class="govuk-button">
+                </div>
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/app/views/task-list.html
+++ b/app/views/task-list.html
@@ -6,10 +6,12 @@
 
         <h1 class="govuk-heading-l">{{ i18n.taskList.header }}</h1>
 
-        <div id="appeal-details">
-            <h2 class="govuk-heading-m">{{ hearing.appellant_name }} <a id="logout" class="govuk-link" href="/logout">Logout</a></h2>
-            <p>Appeal reference: {{ hearing.case_reference }}</p>
-        </div>
+        {% if hearing.appellant_name %}
+            <div id="appeal-details">
+                <h2 class="govuk-heading-m">{{ hearing.appellant_name }} <a id="logout" class="govuk-link" href="/logout">Logout</a></h2>
+                <p>Appeal reference: {{ hearing.case_reference }}</p>
+            </div>
+        {% endif %}
     </div>
 </div>
 
@@ -27,7 +29,7 @@
                 {% for question in questions %}
                     {% set answerState = question.answer_state %}
                     <li id="question-{{ question.question_id }}">
-                        <a class="govuk-link" href="/question/{{ hearing.online_hearing_id }}/{{ question.question_id }}">{{ question.question_header_text }}</a>
+                        <a class="govuk-link" href="/question/{{ hearing.online_hearing_id or hearingId }}/{{ question.question_id }}">{{ question.question_header_text }}</a>
                         {% if answerState != 'unanswered' %}
                             <span class="answer-state {{ question.answer_state }}">
                                 {{

--- a/app/views/task-list.html
+++ b/app/views/task-list.html
@@ -6,13 +6,28 @@
 
         <h1 class="govuk-heading-l">{{ i18n.taskList.header }}</h1>
 
+        <div id="appeal-details">
+            <h2 class="govuk-heading-m">{{ hearing.appellant_name }}</h2>
+            <p>Appeal reference: {{ hearing.case_reference }}</p>
+        </div>
+    </div>
+</div>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <div class="divider"></div>
+    </div>
+</div>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
         <div id="task-list">
             <h2 class="govuk-heading-s">Questions from the tribunal</h2>
             <ul class="govuk-list">
                 {% for question in questions %}
                     {% set answerState = question.answer_state %}
                     <li id="question-{{ question.question_id }}">
-                        <a class="govuk-link" href="/question/{{ hearingId }}/{{ question.question_id }}">{{ question.question_header_text }}</a>
+                        <a class="govuk-link" href="/question/{{ hearing.online_hearing_id }}/{{ question.question_id }}">{{ question.question_header_text }}</a>
                         {% if answerState != 'unanswered' %}
                             <span class="answer-state {{ question.answer_state }}">
                                 {{

--- a/app/views/task-list.html
+++ b/app/views/task-list.html
@@ -7,7 +7,7 @@
         <h1 class="govuk-heading-l">{{ i18n.taskList.header }}</h1>
 
         <div id="appeal-details">
-            <h2 class="govuk-heading-m">{{ hearing.appellant_name }}</h2>
+            <h2 class="govuk-heading-m">{{ hearing.appellant_name }} <a id="logout" class="govuk-link" href="/logout">Logout</a></h2>
             <p>Appeal reference: {{ hearing.case_reference }}</p>
         </div>
     </div>

--- a/paths.js
+++ b/paths.js
@@ -2,5 +2,6 @@ module.exports = {
   health: '/health',
   readiness: '/readiness',
   question: '/question',
-  taskList: '/task-list'
+  taskList: '/task-list',
+  login: '/login'
 };

--- a/paths.js
+++ b/paths.js
@@ -3,5 +3,6 @@ module.exports = {
   readiness: '/readiness',
   question: '/question',
   taskList: '/task-list',
-  login: '/login'
+  login: '/login',
+  logout: '/logout'
 };

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "init-declarations": "off",
+    "max-nested-callbacks": "off"
+  }
+}

--- a/test/browser/common.js
+++ b/test/browser/common.js
@@ -1,4 +1,4 @@
-/* eslint-disable init-declarations, no-console */
+/* eslint-disable no-console */
 const puppeteer = require('puppeteer');
 const { createServer } = require('http');
 const createSession = require('app/middleware/session');

--- a/test/browser/health.test.js
+++ b/test/browser/health.test.js
@@ -3,7 +3,6 @@ const { startServices } = require('test/browser/common');
 const testUrl = require('config').get('testUrl');
 
 describe('Health check @smoke', () => {
-  /* eslint-disable-next-line init-declarations */
   let page;
 
   before(async() => {

--- a/test/browser/question.test.js
+++ b/test/browser/question.test.js
@@ -13,12 +13,10 @@ const sampleHearingId = '121';
 const sampleQuestionId = '62';
 
 describe('Question page', () => {
-  /* eslint-disable init-declarations */
   let page;
   let questionPage;
   let hearingId;
   let questionId;
-  /* eslint-enable init-decalarations */
 
   before(async() => {
     const res = await startServices({ bootstrapCoh: true });

--- a/test/browser/task-list.test.js
+++ b/test/browser/task-list.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-expressions */
 const { expect } = require('test/chai-sinon');
 const { startServices } = require('test/browser/common');
 const mockData = require('test/mock/services/allQuestions').template;
@@ -12,13 +11,11 @@ const sampleHearingId = '121';
 const sampleQuestionId = '001';
 
 describe('Task list page', () => {
-  /* eslint-disable init-declarations */
   let page;
   let taskListpage;
   let hearingId;
   let questionId;
   let questionHeader;
-  /* eslint-enable init-decalarations */
 
   before(async() => {
     const res = await startServices({ bootstrapCoh: true });

--- a/test/mock/services/hearing.js
+++ b/test/mock/services/hearing.js
@@ -1,0 +1,9 @@
+module.exports = {
+  path: '/continuous-online-hearings',
+  method: 'GET',
+  template: {
+    appellant_name: 'Adam Jenkins',
+    case_reference: 'SC/112/233',
+    online_hearing_id: 'abc-123-def-456'
+  }
+};

--- a/test/mock/services/hearing.js
+++ b/test/mock/services/hearing.js
@@ -1,6 +1,14 @@
+const { NOT_FOUND } = require('http-status-codes');
+
 module.exports = {
   path: '/continuous-online-hearings',
   method: 'GET',
+  status: (req, res, next) => {
+    if (req.query.email === 'not.found@example.com') {
+      res.status(NOT_FOUND);
+    }
+    next();
+  },
   template: {
     appellant_name: 'Adam Jenkins',
     case_reference: 'SC/112/233',

--- a/test/mock/services/hearing.js
+++ b/test/mock/services/hearing.js
@@ -1,4 +1,4 @@
-const { NOT_FOUND } = require('http-status-codes');
+const { NOT_FOUND, UNPROCESSABLE_ENTITY } = require('http-status-codes');
 
 module.exports = {
   path: '/continuous-online-hearings',
@@ -6,6 +6,9 @@ module.exports = {
   status: (req, res, next) => {
     if (req.query.email === 'not.found@example.com') {
       res.status(NOT_FOUND);
+    }
+    if (req.query.email === 'multiple@example.com') {
+      res.status(UNPROCESSABLE_ENTITY);
     }
     next();
   },

--- a/test/unit/controllers/login.test.js
+++ b/test/unit/controllers/login.test.js
@@ -1,5 +1,5 @@
 const { expect, sinon } = require('test/chai-sinon');
-const { getLogin, postLogin, setupLoginController } = require('app/controllers/login');
+const { getLogin, getLogout, postLogin, setupLoginController } = require('app/controllers/login');
 const appInsights = require('app-insights');
 const express = require('express');
 const paths = require('paths');
@@ -17,7 +17,8 @@ describe('controllers/login.js', () => {
   beforeEach(() => {
     req = {
       session: {
-        question: {}
+        question: {},
+        destroy: sinon.stub().yields()
       },
       body: {
         'email-address': 'test@example.com'
@@ -39,6 +40,14 @@ describe('controllers/login.js', () => {
     it('renders the template', () => {
       getLogin(req, res);
       expect(res.render).to.have.been.calledWith('login.html');
+    });
+  });
+
+  describe('#getLogout', () => {
+    it('destroys the session and redirects to login', () => {
+      getLogout(req, res);
+      expect(req.session.destroy).to.have.been.calledOnce.calledWith();
+      expect(res.redirect).to.have.been.calledOnce.calledWith(paths.login);
     });
   });
 

--- a/test/unit/controllers/login.test.js
+++ b/test/unit/controllers/login.test.js
@@ -1,0 +1,114 @@
+const { expect, sinon } = require('test/chai-sinon');
+const { getLogin, postLogin, setupLoginController } = require('app/controllers/login');
+const appInsights = require('app-insights');
+const express = require('express');
+const paths = require('paths');
+
+describe('controllers/login.js', () => {
+  let next;
+  let req;
+  let res;
+  const hearingDetails = {
+    online_hearing_id: '1',
+    case_reference: 'SC/123/456',
+    appellant_name: 'John Smith'
+  };
+
+  beforeEach(() => {
+    req = {
+      session: {
+        question: {}
+      },
+      body: {
+        'email-address': 'test@example.com'
+      }
+    };
+    res = {
+      render: sinon.stub(),
+      redirect: sinon.stub()
+    };
+    next = sinon.stub();
+    sinon.stub(appInsights, 'trackException');
+  });
+
+  afterEach(() => {
+    appInsights.trackException.restore();
+  });
+
+  describe('#getLogin', () => {
+    it('renders the template', () => {
+      getLogin(req, res);
+      expect(res.render).to.have.been.calledWith('login.html');
+    });
+  });
+
+  describe('#postLogin', () => {
+    let getOnlineHearingService;
+
+    describe('on success', () => {
+      beforeEach(async() => {
+        getOnlineHearingService = sinon.stub().resolves(hearingDetails);
+        await postLogin(getOnlineHearingService)(req, res, next);
+      });
+
+      it('calls the online hearing service', () => {
+        expect(getOnlineHearingService).to.have.been.calledOnce.calledWith(req.body['email-address']);
+      });
+
+      it('redirects to task list page', () => {
+        expect(res.redirect).to.have.been.calledWith(paths.taskList);
+      });
+    });
+
+    describe('on error', () => {
+      const error = new Error('getOnlineHearingService error');
+
+      beforeEach(async() => {
+        getOnlineHearingService = sinon.stub().rejects(error);
+        await postLogin(getOnlineHearingService)(req, res, next);
+      });
+
+      it('tracks the exception', () => {
+        expect(appInsights.trackException).to.have.been.calledOnce.calledWith(error);
+      });
+      it('calls next with the error', () => {
+        expect(next).to.have.been.calledWith(error);
+      });
+    });
+  });
+
+  describe('#setupLoginController', () => {
+    const deps = {
+      getOnlineHearingService: {}
+    };
+
+    beforeEach(() => {
+      sinon.stub(express, 'Router').returns({
+        get: sinon.stub(),
+        post: sinon.stub()
+      });
+    });
+
+    afterEach(() => {
+      express.Router.restore();
+    });
+
+    it('sets up GET', () => {
+      setupLoginController(deps);
+      // eslint-disable-next-line new-cap
+      expect(express.Router().get).to.have.been.calledWith(paths.login);
+    });
+
+    it('sets up POST', () => {
+      setupLoginController(deps);
+      // eslint-disable-next-line new-cap
+      expect(express.Router().post).to.have.been.calledWith(paths.login);
+    });
+
+    it('returns the router', () => {
+      const controller = setupLoginController(deps);
+      // eslint-disable-next-line new-cap
+      expect(controller).to.equal(express.Router());
+    });
+  });
+});

--- a/test/unit/controllers/question.test.js
+++ b/test/unit/controllers/question.test.js
@@ -33,7 +33,6 @@ describe('controllers/question.js', () => {
   });
 
   describe('getQuestion', () => {
-    // eslint-disable-next-line init-declarations
     let getQuestionService;
 
     beforeEach(() => {
@@ -71,7 +70,6 @@ describe('controllers/question.js', () => {
   });
 
   describe('postAnswer', () => {
-    // eslint-disable-next-line init-declarations
     let postAnswerService;
 
     beforeEach(() => {

--- a/test/unit/controllers/taskList.test.js
+++ b/test/unit/controllers/taskList.test.js
@@ -23,7 +23,6 @@ describe('controllers/taskList.js', () => {
   });
 
   describe('getTaskList', () => {
-    // eslint-disable-next-line init-declarations
     let getAllQuestionsService;
 
     beforeEach(() => {

--- a/test/unit/controllers/taskList.test.js
+++ b/test/unit/controllers/taskList.test.js
@@ -49,7 +49,7 @@ describe('controllers/taskList.js', () => {
       ];
       getAllQuestionsService = () => Promise.resolve({ questions });
       await getTaskList(getAllQuestionsService)(req, res, next);
-      expect(res.render).to.have.been.calledWith('task-list.html', { questions });
+      expect(res.render).to.have.been.calledWith('task-list.html', { hearingId: '1', questions });
     });
 
     it('should call next and appInsights with the error when there is one', async() => {

--- a/test/unit/controllers/taskList.test.js
+++ b/test/unit/controllers/taskList.test.js
@@ -3,18 +3,28 @@ const { setupTaskListController, getTaskList } = require('app/controllers/taskLi
 const { INTERNAL_SERVER_ERROR } = require('http-status-codes');
 const appInsights = require('app-insights');
 const express = require('express');
+const paths = require('paths');
 
 describe('controllers/taskList.js', () => {
-  const next = sinon.stub();
-  const req = {}, res = {};
-
-  req.params = {
-    hearingId: '1'
+  let req;
+  let res;
+  let next;
+  const hearingDetails = {
+    online_hearing_id: '1',
+    case_reference: 'SC/123/456',
+    appellant_name: 'John Smith'
   };
 
-  res.render = sinon.stub();
-
   beforeEach(() => {
+    req = {
+      session: {
+        hearing: hearingDetails
+      }
+    };
+    res = {
+      render: sinon.stub()
+    };
+    next = sinon.stub();
     sinon.stub(appInsights, 'trackException');
   });
 
@@ -39,10 +49,7 @@ describe('controllers/taskList.js', () => {
       ];
       getAllQuestionsService = () => Promise.resolve({ questions });
       await getTaskList(getAllQuestionsService)(req, res, next);
-      expect(res.render).to.have.been.calledWith('task-list.html', {
-        hearingId: req.params.hearingId,
-        questions
-      });
+      expect(res.render).to.have.been.calledWith('task-list.html', { questions });
     });
 
     it('should call next and appInsights with the error when there is one', async() => {
@@ -73,7 +80,7 @@ describe('controllers/taskList.js', () => {
     it('calls router.get with the path and middleware', () => {
       setupTaskListController(deps);
       // eslint-disable-next-line new-cap
-      expect(express.Router().get).to.have.been.calledWith('/:hearingId');
+      expect(express.Router().get).to.have.been.calledWith(paths.taskList);
     });
 
     it('returns the router', () => {

--- a/test/unit/middleware/ensure-authenticated.test.js
+++ b/test/unit/middleware/ensure-authenticated.test.js
@@ -1,0 +1,67 @@
+const { expect, sinon } = require('test/chai-sinon');
+const { verifyOnlineHearingId, setLocals, ensureAuthenticated } = require('app/middleware/ensure-authenticated');
+const paths = require('paths');
+
+describe('middleware/ensure-authenticated', () => {
+  let req;
+  let res;
+  let next;
+  const hearingDetails = {
+    online_hearing_id: '1',
+    case_reference: 'SC/123/456',
+    appellant_name: 'John Smith'
+  };
+
+  beforeEach(() => {
+    req = {
+      session: {
+        id: '123',
+        hearing: hearingDetails,
+        destroy: sinon.stub().yields()
+      }
+    };
+    res = {
+      redirect: sinon.spy(),
+      locals: {}
+    };
+    next = sinon.spy();
+  });
+
+  describe('#verifyOnlineHearingId', () => {
+    it('calls next when hearing ID exists in the session', () => {
+      verifyOnlineHearingId(req, res, next);
+      expect(next).to.have.been.calledOnce.calledWith();
+    });
+
+    describe('when no hearing ID exists', () => {
+      beforeEach(() => {
+        delete req.session.hearing;
+        verifyOnlineHearingId(req, res, next);
+      });
+
+      it('destroys the session and redirects to login', () => {
+        expect(req.session.destroy).to.have.been.calledOnce.calledWith();
+        expect(res.redirect).to.have.been.calledOnce.calledWith(paths.login);
+      });
+
+      it('does not call next', () => (
+        expect(next).to.not.have.been.called
+      ));
+    });
+  });
+
+  describe('#setLocals', () => {
+    it('sets hearing data on the locals', () => {
+      setLocals(req, res, next);
+      expect(res.locals).to.deep.equal({ hearing: hearingDetails });
+    });
+  });
+
+  describe('#ensureAuthenicated', () => {
+    it('is an array of middleware functions', () => {
+      expect(ensureAuthenticated).to.be.an('array');
+      /* eslint-disable-next-line no-magic-numbers */
+      expect(ensureAuthenticated).to.have.lengthOf(2);
+    });
+  });
+});

--- a/test/unit/middleware/error-handler.test.js
+++ b/test/unit/middleware/error-handler.test.js
@@ -2,7 +2,6 @@ const { INTERNAL_SERVER_ERROR, NOT_FOUND } = require('http-status-codes');
 const { expect, sinon } = require('test/chai-sinon');
 const errorHandler = require('app/middleware/error-handler');
 
-/* eslint-disable init-declarations */
 describe('middleware/error-handler', () => {
   let req;
   let res;

--- a/test/unit/middleware/health.test.js
+++ b/test/unit/middleware/health.test.js
@@ -7,7 +7,6 @@ const { livenessCheck, readinessCheck } = require('app/middleware/health');
 
 const apiUrl = config.get('api.url');
 
-/* eslint-disable init-declarations */
 describe('middleware/health', () => {
   let req;
   let res;

--- a/test/unit/middleware/session.test.js
+++ b/test/unit/middleware/session.test.js
@@ -1,7 +1,6 @@
 const { expect } = require('test/chai-sinon');
 const createSession = require('app/middleware/session');
 
-/* eslint-disable init-declarations */
 describe('middleware/session', () => {
   it('exports session middleware function', () => {
     expect(createSession()).to.be.a('function');

--- a/test/unit/services/getOnlineHearing.test.js
+++ b/test/unit/services/getOnlineHearing.test.js
@@ -10,7 +10,7 @@ describe('services/getOnlineHearing.js', () => {
   const email = 'test@example.com';
   const path = '/continuous-online-hearings';
 
-  const apiResponse = {
+  const apiResponseBody = {
     appellant_name: 'Adam Jenkins',
     case_reference: 'SC/112/233',
     online_hearing_id: 'abc-123-def-456'
@@ -21,16 +21,17 @@ describe('services/getOnlineHearing.js', () => {
       nock(apiUrl)
         .get(path)
         .query({ email })
-        .reply(OK, apiResponse);
+        .reply(OK, apiResponseBody);
     });
 
     it('resolves the promise', () => (
       expect(getOnlineHearingService(email)).to.be.fulfilled
     ));
 
-    it('resolves the promise with the response', () => (
-      expect(getOnlineHearingService(email)).to.eventually.eql(apiResponse)
-    ));
+    it('resolves the promise with the response', async() => {
+      const response = await getOnlineHearingService(email);
+      expect(response.body).to.deep.equal(apiResponseBody);
+    });
   });
 
   describe('error response', () => {
@@ -56,8 +57,9 @@ describe('services/getOnlineHearing.js', () => {
         .reply(NOT_FOUND);
     });
 
-    it('rejects the promise', () => (
-      expect(getOnlineHearingService(email)).to.be.rejectedWith('Not Found')
-    ));
+    it('resolves the promise with 404 status', async() => {
+      const response = await getOnlineHearingService(email);
+      expect(response.status).to.equal(NOT_FOUND);
+    });
   });
 });

--- a/test/unit/services/getOnlineHearing.test.js
+++ b/test/unit/services/getOnlineHearing.test.js
@@ -1,6 +1,6 @@
 const getOnlineHearingService = require('app/services/getOnlineHearing');
 const { expect } = require('test/chai-sinon');
-const { OK, INTERNAL_SERVER_ERROR, NOT_FOUND } = require('http-status-codes');
+const { OK, INTERNAL_SERVER_ERROR, NOT_FOUND, UNPROCESSABLE_ENTITY } = require('http-status-codes');
 const nock = require('nock');
 const config = require('config');
 
@@ -60,6 +60,20 @@ describe('services/getOnlineHearing.js', () => {
     it('resolves the promise with 404 status', async() => {
       const response = await getOnlineHearingService(email);
       expect(response.status).to.equal(NOT_FOUND);
+    });
+  });
+
+  describe('multiple hearings found', () => {
+    beforeEach(() => {
+      nock(apiUrl)
+        .get(path)
+        .query({ email })
+        .reply(UNPROCESSABLE_ENTITY);
+    });
+
+    it('resolves the promise with 422 status', async() => {
+      const response = await getOnlineHearingService(email);
+      expect(response.status).to.equal(UNPROCESSABLE_ENTITY);
     });
   });
 });

--- a/test/unit/services/getOnlineHearing.test.js
+++ b/test/unit/services/getOnlineHearing.test.js
@@ -1,0 +1,63 @@
+const getOnlineHearingService = require('app/services/getOnlineHearing');
+const { expect } = require('test/chai-sinon');
+const { OK, INTERNAL_SERVER_ERROR, NOT_FOUND } = require('http-status-codes');
+const nock = require('nock');
+const config = require('config');
+
+const apiUrl = config.get('api.url');
+
+describe('services/getOnlineHearing.js', () => {
+  const email = 'test@example.com';
+  const path = '/continuous-online-hearings';
+
+  const apiResponse = {
+    appellant_name: 'Adam Jenkins',
+    case_reference: 'SC/112/233',
+    online_hearing_id: 'abc-123-def-456'
+  };
+
+  describe('success response', () => {
+    beforeEach(() => {
+      nock(apiUrl)
+        .get(path)
+        .query({ email })
+        .reply(OK, apiResponse);
+    });
+
+    it('resolves the promise', () => (
+      expect(getOnlineHearingService(email)).to.be.fulfilled
+    ));
+
+    it('resolves the promise with the response', () => (
+      expect(getOnlineHearingService(email)).to.eventually.eql(apiResponse)
+    ));
+  });
+
+  describe('error response', () => {
+    const error = { value: INTERNAL_SERVER_ERROR, reason: 'Server Error' };
+
+    beforeEach(() => {
+      nock(apiUrl)
+        .get(path)
+        .query({ email })
+        .replyWithError(error);
+    });
+
+    it('rejects the promise with the error', () => (
+      expect(getOnlineHearingService(email)).to.be.rejectedWith(error)
+    ));
+  });
+
+  describe('hearing not found', () => {
+    beforeEach(() => {
+      nock(apiUrl)
+        .get(path)
+        .query({ email })
+        .reply(NOT_FOUND);
+    });
+
+    it('rejects the promise', () => (
+      expect(getOnlineHearingService(email)).to.be.rejectedWith('Not Found')
+    ));
+  });
+});

--- a/test/unit/utils/fieldValidation.test.js
+++ b/test/unit/utils/fieldValidation.test.js
@@ -19,11 +19,11 @@ describe('utils/fieldValidation.js', () => {
     });
 
     it('returns the error message if answer is not an email', () => {
-      expect(loginEmailAddressValidation('not.an.email')).to.equal(i18n.login.emailAddress.error.empty);
+      expect(loginEmailAddressValidation('not.an.email')).to.equal(i18n.login.emailAddress.error.format);
     });
 
     it('returns false if answer is valid', () => {
-      expect(answerValidation('test@example.com')).to.equal(false);
+      expect(loginEmailAddressValidation('test@example.com')).to.equal(false);
     });
   });
 });

--- a/test/unit/utils/fieldValidation.test.js
+++ b/test/unit/utils/fieldValidation.test.js
@@ -1,5 +1,5 @@
 const { expect } = require('test/chai-sinon');
-const { answerValidation } = require('app/utils/fieldValidation');
+const { answerValidation, loginEmailAddressValidation } = require('app/utils/fieldValidation');
 const i18n = require('app/locale/en');
 
 describe('utils/fieldValidation.js', () => {
@@ -10,6 +10,20 @@ describe('utils/fieldValidation.js', () => {
 
     it('returns false if answer is valid', () => {
       expect(answerValidation('Valid answer')).to.equal(false);
+    });
+  });
+
+  describe('loginEmailAddressValidation', () => {
+    it('returns the error message if answer is empty', () => {
+      expect(loginEmailAddressValidation('')).to.equal(i18n.login.emailAddress.error.empty);
+    });
+
+    it('returns the error message if answer is not an email', () => {
+      expect(loginEmailAddressValidation('not.an.email')).to.equal(i18n.login.emailAddress.error.empty);
+    });
+
+    it('returns false if answer is valid', () => {
+      expect(answerValidation('test@example.com')).to.equal(false);
     });
   });
 });


### PR DESCRIPTION
Adding a simple login page which asks for email address only. This enables us to ask the backend for the online hearing ID, name and case reference.

This login page is a temporary solution until IDAM is implemented for user registration and sign-in.

When using the login page with an email address associated with a case in CCD it should now display the associated name and case reference.

At this stage, the app still functions as it previously did, allowing you to go directly to a task-list for an online hearing by adding it as a query parameter. This should be removed in a later iteration once we have a solution for functionally testing the sign-in and retrieve online hearing relating to an appeal in CCD!

I would like to add some browser tests to cover the login functionality, which would need to run just locally for now, but I would rather do this as a separate PR to prevent this one growing even more!

**Screenshot**

<img width="1010" alt="task-list-with-appellant-details" src="https://user-images.githubusercontent.com/1334068/44532851-061f3000-a6ec-11e8-9d7f-b56173a0da57.png">

**Some other tweaks include:**
- eslint max line length is now 120 🎉
- disabling some eslint rules for the test directory