### PR TITLE
[PREVIEW] SSCS-3554 More functional testing and enforcing "login"

### DIFF
--- a/app/server/controllers/question.ts
+++ b/app/server/controllers/question.ts
@@ -48,7 +48,7 @@ function postAnswer(updateAnswerService) {
         if (req.body.submit) {
           res.redirect(`${paths.question}/${hearingId}/${questionId}/submit`);
         } else {
-          res.redirect(`${paths.taskList}/${hearingId}`);
+          res.redirect(paths.taskList);
         }
       } catch (error) {
         appInsights.trackException(error);
@@ -61,10 +61,8 @@ function postAnswer(updateAnswerService) {
 function setupQuestionController(deps) {
   // eslint-disable-next-line new-cap
   const router = express.Router();
-  // using setLocals to ensure the case_reference is available if logged in
-  // this will need to be changed when handling auth properly using IDAM
-  router.get('/:hearingId/:questionId', deps.setLocals, getQuestion(deps.getQuestionService));
-  router.post('/:hearingId/:questionId', postAnswer(deps.saveAnswerService));
+  router.get('/:hearingId/:questionId', deps.ensureAuthenticated, getQuestion(deps.getQuestionService));
+  router.post('/:hearingId/:questionId', deps.ensureAuthenticated, postAnswer(deps.saveAnswerService));
   return router;
 }
 

--- a/app/server/controllers/submit_question.ts
+++ b/app/server/controllers/submit_question.ts
@@ -21,7 +21,7 @@ function postSubmitAnswer(submitAnswerService: any) {
 
     try {
       await submitAnswerService(hearingId, questionId);
-      res.redirect(`${paths.taskList}/${hearingId}`);
+      res.redirect(paths.taskList);
     } catch (error) {
       appInsights.trackException(error);
       next(error);
@@ -32,8 +32,8 @@ function postSubmitAnswer(submitAnswerService: any) {
 function setupSubmitQuestionController(deps: any) {
   // eslint-disable-next-line new-cap
   const router = express.Router();
-  router.get(`${paths.question}/:hearingId/:questionId/submit`, getSubmitQuestion());
-  router.post(`${paths.question}/:hearingId/:questionId/submit`, postSubmitAnswer(deps.submitAnswerService));
+  router.get(`${paths.question}/:hearingId/:questionId/submit`, deps.ensureAuthenticated, getSubmitQuestion());
+  router.post(`${paths.question}/:hearingId/:questionId/submit`, deps.ensureAuthenticated, postSubmitAnswer(deps.submitAnswerService));
   return router;
 }
 

--- a/app/server/controllers/taskList.ts
+++ b/app/server/controllers/taskList.ts
@@ -45,7 +45,6 @@ function getTaskList(getAllQuestionsService: any) {
 function setupTaskListController(deps: any): Router {
   const router: Router = Router();
   router.get(paths.taskList, deps.ensureAuthenticated, getTaskList(deps.getAllQuestionsService));
-  router.get(`${paths.taskList}/:hearingId`, getTaskList(deps.getAllQuestionsService));
   return router;
 }
 

--- a/app/server/routes.ts
+++ b/app/server/routes.ts
@@ -18,11 +18,9 @@ const { saveAnswer: saveAnswerService, submitAnswer: submitAnswerService } = req
 const questionController = setupQuestionController({
   getQuestionService,
   saveAnswerService,
-  // just passing setLocals to ensure the case_reference is available if logged in
-  // this will need to be changed when handling auth properly using IDAM
-  setLocals
+  ensureAuthenticated
 });
-const submitQuestionController = setupSubmitQuestionController({ submitAnswerService });
+const submitQuestionController = setupSubmitQuestionController({ submitAnswerService, ensureAuthenticated });
 const taskListController = setupTaskListController({ getAllQuestionsService, ensureAuthenticated });
 const loginController = setupLoginController({ getOnlineHearingService });
 

--- a/app/server/views/question.html
+++ b/app/server/views/question.html
@@ -4,8 +4,7 @@
 
 {% block beforeContent %}
     {{ super() }}
-    {% set taskListPath = '/' + question.hearingId if not hearing.online_hearing_id else '' %}
-    <a href="/task-list{{ taskListPath }}" class="govuk-back-link">{{ i18n.backLink }}</a>
+    <a href="/task-list" class="govuk-back-link">{{ i18n.backLink }}</a>
 {% endblock %}
 
 {% block content %}

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "istanbul": "1.1.0-alpha.1",
     "jsdom": "^11.12.0",
     "jsdom-global": "^3.0.2",
+    "memory-cache": "^0.2.0",
     "mocha": "^3.2.0",
     "mocha-jenkins-reporter": "^0.3.8",
     "nock": "^9.4.4",

--- a/test/browser/1-task-list.test.ts
+++ b/test/browser/1-task-list.test.ts
@@ -67,6 +67,11 @@ describe('Task list page', () => {
     expect(displayedQuestionHeader).to.equal(questionHeader);
   });
 
+  it('displays question status as unanswered', async() => {
+    const answerElement = await taskListPage.getElement(`#question-${questionId} .answer-state`);
+    expect(answerElement).to.be.null;
+  });
+
   it('redirects to the question page for that question', async() => {
     await taskListPage.clickQuestion(questionId);
     expect(taskListPage.getCurrentUrl())

--- a/test/browser/2-question.test.ts
+++ b/test/browser/2-question.test.ts
@@ -21,6 +21,8 @@ describe('Question page', () => {
   let submitQuestionPage;
   let hearingId;
   let questionId;
+  let questionHeader;
+  let questionBody;
   let caseReference;
 
   before('start services and bootstrap data in CCD/COH', async() => {
@@ -28,6 +30,8 @@ describe('Question page', () => {
     page = res.page;
     hearingId = res.cohTestData.hearingId || sampleHearingId;
     questionId = res.cohTestData.questionId || sampleQuestionId;
+    questionHeader = res.cohTestData.questionHeader || mockDataQuestion.question_header_text({ questionId: sampleQuestionId });
+    questionBody = res.cohTestData.questionBody || mockDataQuestion.question_body_text({ questionId: sampleQuestionId });
     caseReference = res.ccdCase.caseReference || mockDataHearing.case_reference;
     taskListPage = new TaskListPage(page)
     questionPage = new QuestionPage(page, hearingId, questionId);
@@ -47,11 +51,11 @@ describe('Question page', () => {
   });
 
   it('displays question heading from api request', async() => {
-    expect(await questionPage.getHeading()).to.equal(mockDataQuestion.question_header_text);
+    expect(await questionPage.getHeading()).to.equal(questionHeader);
   });
 
   it('displays question body from api request', async() => {
-    expect(await questionPage.getBody()).to.contain(mockDataQuestion.question_body_text);
+    expect(await questionPage.getBody()).to.contain(questionBody);
   });
 
   it('displays question answer box', async() => (
@@ -76,10 +80,9 @@ describe('Question page', () => {
   describe('saving an answer', () => {
     it('redirects to /task-list page when a valid answer is saved', async() => {
       await questionPage.saveAnswer('A valid answer');
-      expect(questionPage.getCurrentUrl()).to.equal(`${testUrl}${paths.taskList}/${hearingId}`);
+      expect(questionPage.getCurrentUrl()).to.equal(`${testUrl}${paths.taskList}`);
     });
 
-    // TODO: add state to mocks to be able to test this properly
     it('displays question status as draft', async() => {
       const answerState = await taskListPage.getElementText(`#question-${questionId} .answer-state`);
       expect(answerState).to.equal(i18n.taskList.answerState.draft.toUpperCase())
@@ -91,21 +94,22 @@ describe('Question page', () => {
       await taskListPage.clickQuestion(questionId);
     });
 
-    // TODO: add state to mocks to be able to test this
-    it('displays the previously drafted answer');
+    it('displays the previously drafted answer', async() => {
+      const savedAnswer = await questionPage.getElementValue('#question-field');
+      expect(savedAnswer).to.equal('A valid answer')
+    });
 
     it('is on the /submit_answer path after submitting answer', async() => {
-      await questionPage.submitAnswer('A valid answer');
+      await questionPage.submitAnswer('Another valid answer');
       submitQuestionPage.verifyPage();
     });
 
     it('redirects to /task-list page when a valid answer is submitted', async() => {
       await submitQuestionPage.submit();
-      expect(submitQuestionPage.getCurrentUrl()).to.equal(`${testUrl}${paths.taskList}/${hearingId}`);
+      expect(submitQuestionPage.getCurrentUrl()).to.equal(`${testUrl}${paths.taskList}`);
     });
 
-    // TODO: add state to mocks to be able to test this
-    it.skip('displays question status as completed', async() => {
+    it('displays question status as completed', async() => {
       const answerState = await taskListPage.getElementText(`#question-${questionId} .answer-state`);
       expect(answerState).to.equal(i18n.taskList.answerState.completed.toUpperCase())
     });

--- a/test/browser/common.ts
+++ b/test/browser/common.ts
@@ -88,8 +88,9 @@ async function bootstrapCoh() {
       await coh.setQuestionRoundToIssued(hearingId);
       const questionRound = await waitForQuestionRoundIssued(hearingId, 1, null);
       const questionHeader = questionRound.question_references[0].question_header_text;
+      const questionBody = questionRound.question_references[0].question_body_text;
       const deadlineExpiryDate = questionRound.question_references[0].deadline_expiry_date;
-      cohTestData = { hearingId, questionId, questionHeader, deadlineExpiryDate };
+      cohTestData = { hearingId, questionId, questionHeader, questionBody, deadlineExpiryDate };
     } catch (error) {
       console.log('Error bootstrapping COH with test data', error);
       return Promise.reject(error);
@@ -120,8 +121,14 @@ async function login(page) {
 async function startServices(options?) {
   const opts = options || {};
   if (opts.bootstrapData) {
-    await bootstrapCcdCase();
-    await bootstrapCoh();
+    try {
+      await bootstrapCcdCase();
+      await bootstrapCoh();
+    } catch (error) {
+      ccdCase = null;
+      cohTestData = null;
+      return Promise.reject(error);
+    }
   }
   await startAppServer();
   await startBrowser();

--- a/test/fixtures/coh.js
+++ b/test/fixtures/coh.js
@@ -37,8 +37,8 @@ const onlineHearingBody = caseId => {
 
 const questionBody = {
   owner_reference: QUESTION_OWNER_REF,
-  question_body_text: mockData.question_body_text,
-  question_header_text: mockData.question_header_text,
+  question_body_text: mockData.question_body_text({ questionId: '001' }),
+  question_header_text: mockData.question_header_text({ questionId: '001' }),
   question_ordinal: QUESTION_ORDINAL,
   question_round: QUESTION_ROUND
 };
@@ -46,7 +46,7 @@ const questionBody = {
 async function createOnlineHearing(caseId) {
   const options = {
     url: `${cohUrl}/continuous-online-hearings`,
-    headers: { ...headers },
+    headers,
     body: onlineHearingBody(caseId),
     json: true
   };
@@ -58,7 +58,7 @@ async function createOnlineHearing(caseId) {
 async function createQuestion(hearingId) {
   const options = {
     url: `${cohUrl}/continuous-online-hearings/${hearingId}/questions`,
-    headers: { ...headers },
+    headers,
     body: questionBody,
     json: true
   };
@@ -70,7 +70,7 @@ async function createQuestion(hearingId) {
 async function setQuestionRoundToIssued(hearingId) {
   const options = {
     url: `${cohUrl}/continuous-online-hearings/${hearingId}/questionrounds/1`,
-    headers: { ...headers },
+    headers,
     body: { state_name: 'question_issue_pending' },
     json: true
   };
@@ -81,7 +81,7 @@ async function setQuestionRoundToIssued(hearingId) {
 async function getQuestionRound(hearingId, roundNum) {
   const options = {
     url: `${cohUrl}/continuous-online-hearings/${hearingId}/questionrounds/${roundNum}`,
-    headers: { ...headers },
+    headers,
     json: true
   };
   const body = await rp.get(options);

--- a/test/mock/services/allQuestions.js
+++ b/test/mock/services/allQuestions.js
@@ -1,4 +1,6 @@
+const cache = require('memory-cache');
 const moment = require('moment');
+const questionData = require('./questionData');
 
 const hearingIdToDeadlineStatusMap = {
   '2-completed': 'completed',
@@ -6,37 +8,40 @@ const hearingIdToDeadlineStatusMap = {
 };
 
 function deadlineDate(hearingId) {
-  const status = hearingIdToDeadlineStatusMap[hearingId];
-  if (status === 'expired') {
+  const deadlineStatus = hearingIdToDeadlineStatusMap[hearingId];
+  if (deadlineStatus === 'expired') {
     return moment().utc().subtract(1, 'day').endOf('day').format();
   }
   /* eslint-disable-next-line no-magic-numbers */
   return moment().utc().add(7, 'days').endOf('day').format();
 }
 
-function answerState(hearingId, defaultValue) {
-  const status = hearingIdToDeadlineStatusMap[hearingId];
-  return status === 'completed' ? 'submitted' : defaultValue;
+function answerState(questionId, hearingId) {
+  const DEFAULT_ANSWER_STATE = 'unanswered';
+  const deadlineStatus = hearingIdToDeadlineStatusMap[hearingId];
+  const cachedState = cache.get(`${questionId}.state`);
+  return deadlineStatus === 'completed' ? 'submitted' : cachedState || DEFAULT_ANSWER_STATE;
 }
 
 module.exports = {
   path: '/continuous-online-hearings/:onlineHearingId',
   method: 'GET',
+  cache: false,
   template: {
     deadline_expiry_date: params => deadlineDate(params.onlineHearingId),
     questions: params => [
       {
         question_id: '001',
-        question_header_text: 'How do you interact with people?',
-        answer_state: answerState(params.onlineHearingId, 'draft')
+        question_header_text: questionData['001'].header,
+        answer_state: answerState('001', params.onlineHearingId)
       }, {
         question_id: '002',
-        question_header_text: 'How do you walk to the doctors?',
-        answer_state: answerState(params.onlineHearingId, 'submitted')
+        question_header_text: questionData['002'].header,
+        answer_state: answerState('002', params.onlineHearingId)
       }, {
         question_id: '003',
-        question_header_text: 'Tell us about your migraines',
-        answer_state: answerState(params.onlineHearingId, 'unanswered')
+        question_header_text: questionData['003'].header,
+        answer_state: answerState('003', params.onlineHearingId)
       }
     ]
   }

--- a/test/mock/services/answer.js
+++ b/test/mock/services/answer.js
@@ -1,9 +1,17 @@
 const { NO_CONTENT } = require('http-status-codes');
+const cache = require('memory-cache');
+
+function cacheAnswerState(questionId, answerText) {
+  cache.put(`${questionId}.state`, 'draft');
+  cache.put(`${questionId}.answer`, answerText);
+}
 
 module.exports = {
   path: '/continuous-online-hearings/:hearingId/questions/:questionId',
   method: 'PUT',
+  cache: false,
   status: (req, res, next) => {
+    cacheAnswerState(req.params.questionId, req.body.answer);
     res.status(NO_CONTENT);
     next();
   }

--- a/test/mock/services/question.js
+++ b/test/mock/services/question.js
@@ -1,11 +1,19 @@
-/* eslint-disable max-len */
+const cache = require('memory-cache');
+const questionData = require('./questionData');
+
+function getCachedAnswer(questionId) {
+  const cachedAnswer = cache.get(`${questionId}.answer`);
+  return cachedAnswer ? cachedAnswer : '';
+}
+
 module.exports = {
   path: '/continuous-online-hearings/:onlineHearingId/questions/:questionId',
   method: 'GET',
+  cache: false,
   template: {
     question_id: params => `${params.questionId}`,
-    question_header_text: 'How do you interact with people?',
-    question_body_text: 'You said you avoid interacting with people if possible. We\'d like to know more about the times when you see friends and family.\n\nTell us about three separate occasions in 2017 that you have met with friends and family.\n\nTell us:\n\n- who you met\n\n- when\n\n- where\n\n- how it made you feel',
-    answer: ''
+    question_header_text: params => questionData[params.questionId].header,
+    question_body_text: params => questionData[params.questionId].body,
+    answer: params => getCachedAnswer(params.questionId)
   }
 };

--- a/test/mock/services/questionData.js
+++ b/test/mock/services/questionData.js
@@ -1,0 +1,15 @@
+/* eslint-disable max-len */
+module.exports = {
+  '001': {
+    header: 'How do you interact with people?',
+    body: 'You said you avoid interacting with people if possible. We\'d like to know more about the times when you see friends and family.\n\nTell us about three separate occasions in 2017 that you have met with friends and family.\n\nTell us:\n\n- who you met\n\n- when\n\n- where\n\n- how it made you feel'
+  },
+  '002': {
+    header: 'How do you walk to the doctors?',
+    body: 'The DWP healthcare professional noted that you occasionally walk to the GP’s surgery.\n\nIn 2017, please describe the journey, including:\n\n• how long it took\n\n• whether you needed to stop on the way\n\n• if so, for how long\n\n• if you used any aids to help you walk\n\n• if you did, what aids did you use'
+  },
+  '003': {
+    header: 'Tell us about your migraines',
+    body: 'You said you have difficulties caused by migraines.\n\nDuring 2017, can you tell us:\n\n• how often you had migraines\n\n• how long they lasted\n\n• how you deal with them'
+  }
+};

--- a/test/mock/services/sumbit_answer.js
+++ b/test/mock/services/sumbit_answer.js
@@ -1,9 +1,15 @@
 const { NO_CONTENT } = require('http-status-codes');
+const cache = require('memory-cache');
+
+function cacheAnswerState(questionId) {
+  cache.put(`${questionId}.state`, 'submitted');
+}
 
 module.exports = {
   path: '/continuous-online-hearings/:hearingId/questions/:questionId',
   method: 'POST',
   status: (req, res, next) => {
+    cacheAnswerState(req.params.questionId, req.body.answer);
     res.status(NO_CONTENT);
     next();
   }

--- a/test/page-objects/base.js
+++ b/test/page-objects/base.js
@@ -38,6 +38,11 @@ class BasePage {
     return element;
   }
 
+  async getElementValue(selector) {
+    const element = await this.page.$eval(selector, el => el.value);
+    return element;
+  }
+
   async getElement(selector) {
     const element = await this.page.$(selector);
     return element;

--- a/test/page-objects/question.js
+++ b/test/page-objects/question.js
@@ -7,20 +7,21 @@ class QuestionPage extends BasePage {
     this.pagePath = `${question}/${hearingId}/${questionId}`;
   }
 
-  async saveAnswer(answer) {
+  async answer(answer, submit) {
     await this.enterTextintoField('#question-field', answer);
+    const buttonId = submit ? '#submit-answer' : '#save-answer';
     await Promise.all([
       this.page.waitForNavigation(),
-      this.clickElement('#save-answer')
+      this.clickElement(buttonId)
     ]);
   }
 
+  async saveAnswer(answer) {
+    await this.answer(answer, false);
+  }
+
   async submitAnswer(answer) {
-    await this.enterTextintoField('#question-field', answer);
-    await Promise.all([
-      this.page.waitForNavigation(),
-      this.clickElement('#submit-answer')
-    ]);
+    await this.answer(answer, true);
   }
 }
 

--- a/test/unit/controllers/question.test.ts
+++ b/test/unit/controllers/question.test.ts
@@ -85,7 +85,7 @@ describe('controllers/question.js', () => {
       req.body['question-field'] = 'My amazing answer';
       postAnswerService = () => Promise.resolve();
       await postAnswer(postAnswerService)(req, res, next);
-      expect(res.redirect).to.have.been.calledWith(`${paths.taskList}/${req.params.hearingId}`);
+      expect(res.redirect).to.have.been.calledWith(paths.taskList);
     });
 
     it('should call res.redirect when submitting an answer and there are no errors', async() => {

--- a/test/unit/controllers/submit_question.test.ts
+++ b/test/unit/controllers/submit_question.test.ts
@@ -5,7 +5,7 @@ const appInsights = require('app/server/app-insights');
 const paths = require('app/server/paths');
 const express = require('express');
 
-describe('controllers/question.js', () => {
+describe('controllers/submit_question.js', () => {
   const next = sinon.stub();
   const req:any = {}; 
   const res:any = {};
@@ -42,7 +42,7 @@ describe('controllers/question.js', () => {
     it('should call res.redirect when submitting an answer and there are no errors', async() => {
       const submitAnswerService = () => Promise.resolve();
       await postSubmitAnswer(submitAnswerService)(req, res, next);
-      expect(res.redirect).to.have.been.calledWith(`${paths.taskList}/${req.params.hearingId}`);
+      expect(res.redirect).to.have.been.calledWith(paths.taskList);
     });
 
     it('should call next and appInsights with the error when there is one', async() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -131,7 +131,15 @@
     "@types/node" "*"
     "@types/range-parser" "*"
 
-"@types/express@^4.16.0":
+"@types/express-session@^1.15.10":
+  version "1.15.10"
+  resolved "https://registry.yarnpkg.com/@types/express-session/-/express-session-1.15.10.tgz#d0ae7d3d2fee26512574306333ac272a37430c86"
+  dependencies:
+    "@types/events" "*"
+    "@types/express" "*"
+    "@types/node" "*"
+
+"@types/express@*", "@types/express@^4.16.0":
   version "4.16.0"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.16.0.tgz#6d8bc42ccaa6f35cf29a2b7c3333cb47b5a32a19"
   dependencies:
@@ -3492,6 +3500,10 @@ mem@^1.1.0:
   resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
   dependencies:
     mimic-fn "^1.0.0"
+
+memory-cache@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/memory-cache/-/memory-cache-0.2.0.tgz#7890b01d52c00c8ebc9d533e1f8eb17e3034871a"
 
 meow@^3.7.0:
   version "3.7.0"


### PR DESCRIPTION
* adding simple state to mock backend e.g. keeping track of question answer state
* no longer cache any dyson stubs as they are not deterministic anymore
* this is to facilitate more complex functional testing
* protecting all routes behind "auth", from now you must have a valid case in CCD and "login" using the associated email address
* removing use of hearing ID in task list URL, it is held in the redis session after successfully signing in with an email address
* adding extra tests now possible due to having simple state in the stub backend