### PR TITLE
[PREVIEW] SSCS-3583 all questions submitted

### DIFF
--- a/app/server/controllers/question.ts
+++ b/app/server/controllers/question.ts
@@ -5,12 +5,11 @@ const { answerValidation } = require('app/server/utils/fieldValidation');
 
 function getQuestion(getQuestionService) {
   return async(req, res, next) => {
-    const hearingId = req.params.hearingId;
+    const hearingId = req.session.hearing.online_hearing_id;
     const questionId = req.params.questionId;
     try {
       const response = await getQuestionService(hearingId, questionId);
       const question = {
-        hearingId,
         questionId,
         header: response.question_header_text,
         body: response.question_body_text,
@@ -29,7 +28,7 @@ function getQuestion(getQuestionService) {
 
 function postAnswer(updateAnswerService) {
   return async(req, res, next) => {
-    const hearingId = req.params.hearingId;
+    const hearingId = req.session.hearing.online_hearing_id;
     const questionId = req.params.questionId;
     const answerText = req.body['question-field'];
 

--- a/app/server/controllers/questions-completed.ts
+++ b/app/server/controllers/questions-completed.ts
@@ -1,0 +1,26 @@
+import { Router, Request, Response } from 'express';
+const moment = require('moment');
+const paths = require('app/server/paths');
+
+const DATE_FORMAT = 'D MMMM YYYY';
+
+function getQuestionsCompleted(req: Request, res: Response) {
+  if (req.session.questionsCompletedThisSession) {
+    // TODO: refactor to use nunjucks filter
+    const nextCorrespondenceDate = moment().add(7, 'days').format(DATE_FORMAT)
+    return res.render('questions-completed.html', { nextCorrespondenceDate });
+  }
+  return res.redirect(paths.taskList);
+}
+
+function setupQuestionsCompletedController(deps: any) {
+  // eslint-disable-next-line new-cap
+  const router = Router();
+  router.get(paths.completed, deps.ensureAuthenticated, getQuestionsCompleted);
+  return router;
+}
+
+export {
+  setupQuestionsCompletedController,
+  getQuestionsCompleted
+};

--- a/app/server/controllers/submit_question.ts
+++ b/app/server/controllers/submit_question.ts
@@ -2,18 +2,29 @@ import { Router, Request, Response, NextFunction } from "express";
 const appInsights = require('app/server/app-insights');
 const paths = require('app/server/paths');
 
+const getSubmittedQuestionCount = (questions: any) => questions.filter((q: any) => q.answer_state === 'submitted').length;
+
 function getSubmitQuestion(req: Request, res: Response) {
   const questionId = req.params.questionId;
   res.render('submit-question.html', { questionId });
 }
 
-function postSubmitAnswer(submitAnswerService: any) {
+function postSubmitAnswer(submitAnswerService: any, getAllQuestionsService: any) {
   return async(req: Request, res: Response, next: NextFunction) => {
     const hearingId = req.session.hearing.online_hearing_id;
     const questionId = req.params.questionId;
     try {
       await submitAnswerService(hearingId, questionId);
-      res.redirect(paths.taskList);
+
+      const response = await getAllQuestionsService(hearingId);
+      const totalQuestionCount = response.questions.length;
+      const allQuestionsSubmitted = totalQuestionCount === getSubmittedQuestionCount(response.questions);
+
+      if (allQuestionsSubmitted) {
+        req.session.questionsCompletedThisSession = true;
+        return res.redirect(paths.completed);
+      }
+      return res.redirect(paths.taskList);
     } catch (error) {
       appInsights.trackException(error);
       next(error);
@@ -25,7 +36,7 @@ function setupSubmitQuestionController(deps: any) {
   // eslint-disable-next-line new-cap
   const router = Router();
   router.get(`${paths.question}/:hearingId/:questionId/submit`, deps.ensureAuthenticated, getSubmitQuestion);
-  router.post(`${paths.question}/:hearingId/:questionId/submit`, deps.ensureAuthenticated, postSubmitAnswer(deps.submitAnswerService));
+  router.post(`${paths.question}/:hearingId/:questionId/submit`, deps.ensureAuthenticated, postSubmitAnswer(deps.submitAnswerService, deps.getAllQuestionsService));
   return router;
 }
 

--- a/app/server/controllers/submit_question.ts
+++ b/app/server/controllers/submit_question.ts
@@ -1,24 +1,16 @@
+import { Router, Request, Response, NextFunction } from "express";
 const appInsights = require('app/server/app-insights');
-const express = require('express');
 const paths = require('app/server/paths');
 
-function getSubmitQuestion() {
-  return (req: any, res: any) => {
-    const hearingId = req.params.hearingId;
-    const questionId = req.params.questionId;
-    const question = {
-      hearingId,
-      questionId
-    };
-    res.render('submit-question.html', { question });
-  };
+function getSubmitQuestion(req: Request, res: Response) {
+  const questionId = req.params.questionId;
+  res.render('submit-question.html', { questionId });
 }
 
 function postSubmitAnswer(submitAnswerService: any) {
-  return async(req: any, res: any, next: any) => {
-    const hearingId = req.params.hearingId;
+  return async(req: Request, res: Response, next: NextFunction) => {
+    const hearingId = req.session.hearing.online_hearing_id;
     const questionId = req.params.questionId;
-
     try {
       await submitAnswerService(hearingId, questionId);
       res.redirect(paths.taskList);
@@ -31,8 +23,8 @@ function postSubmitAnswer(submitAnswerService: any) {
 
 function setupSubmitQuestionController(deps: any) {
   // eslint-disable-next-line new-cap
-  const router = express.Router();
-  router.get(`${paths.question}/:hearingId/:questionId/submit`, deps.ensureAuthenticated, getSubmitQuestion());
+  const router = Router();
+  router.get(`${paths.question}/:hearingId/:questionId/submit`, deps.ensureAuthenticated, getSubmitQuestion);
   router.post(`${paths.question}/:hearingId/:questionId/submit`, deps.ensureAuthenticated, postSubmitAnswer(deps.submitAnswerService));
   return router;
 }

--- a/app/server/controllers/taskList.ts
+++ b/app/server/controllers/taskList.ts
@@ -24,14 +24,12 @@ const getSubmittedQuestionCount = (questions: any) => questions.filter((q: any) 
 function getTaskList(getAllQuestionsService: any) {
   return async(req: Request, res: Response, next: NextFunction) => {
     const hearing = req.session.hearing;
-    const hearingId = (hearing && hearing.online_hearing_id) || req.params.hearingId;
     try {
-      const response = await getAllQuestionsService(hearingId);
+      const response = await getAllQuestionsService(hearing.online_hearing_id);
       const totalQuestionCount = response.questions.length;
       const allQuestionsSubmitted = totalQuestionCount === getSubmittedQuestionCount(response.questions);
       const deadlineDetails = processDeadline(response.deadline_expiry_date, allQuestionsSubmitted);
       res.render('task-list.html', {
-        hearingId,
         deadlineExpiryDate: deadlineDetails,
         questions: response.questions
       });

--- a/app/server/locale/en.json
+++ b/app/server/locale/en.json
@@ -72,6 +72,13 @@
     "title": "You will not be able to change your answer after you submit it.",
     "backToQuestionText": "Back to question"
   },
+  "questionsCompleted": {
+    "header": "You have answered the tribunal’s questions",
+    "para1": "You’ve provided the information the tribunal have asked for. They’ll review what you’ve sent and consider it as part of your appeal.",
+    "para2Start": "You’ll get another email by",
+    "para2End": "which will explain how the tribunal want to proceed with your appeal.",
+    "exitService": "Exit service"
+  },
   "error": {
     "error404": {
       "header": "Sorry, this page could not be found"

--- a/app/server/paths.js
+++ b/app/server/paths.js
@@ -4,5 +4,6 @@ module.exports = {
   question: '/question',
   taskList: '/task-list',
   login: '/login',
-  logout: '/logout'
+  logout: '/logout',
+  completed: '/questions-completed'
 };

--- a/app/server/routes.ts
+++ b/app/server/routes.ts
@@ -1,9 +1,10 @@
 const express = require('express');
 const paths = require('app/server/paths');
-const { ensureAuthenticated, setLocals } = require('app/server/middleware/ensure-authenticated');
+const { ensureAuthenticated } = require('app/server/middleware/ensure-authenticated');
 
 import { setupQuestionController } from './controllers/question';
 import { setupSubmitQuestionController } from './controllers/submit_question';
+import { setupQuestionsCompletedController } from './controllers/questions-completed';
 import { setupTaskListController } from './controllers/taskList';
 import { setupLoginController } from './controllers/login';
 
@@ -20,12 +21,14 @@ const questionController = setupQuestionController({
   saveAnswerService,
   ensureAuthenticated
 });
-const submitQuestionController = setupSubmitQuestionController({ submitAnswerService, ensureAuthenticated });
+const submitQuestionController = setupSubmitQuestionController({ submitAnswerService, getAllQuestionsService, ensureAuthenticated });
+const questionsCompletedController = setupQuestionsCompletedController({ ensureAuthenticated });
 const taskListController = setupTaskListController({ getAllQuestionsService, ensureAuthenticated });
 const loginController = setupLoginController({ getOnlineHearingService });
 
 router.use(loginController);
 router.use(submitQuestionController);
+router.use(questionsCompletedController);
 router.use(paths.question, questionController);
 router.use(taskListController);
 

--- a/app/server/views/includes/sending-evidence-contact-details.html
+++ b/app/server/views/includes/sending-evidence-contact-details.html
@@ -1,4 +1,4 @@
 <h2 class="govuk-heading-s">{{ i18n.guidance.sendingEvidence.byEmailHeader }}</h2>
-<p><a href="mailto:{{ i18n.guidance.sendingEvidence.emailAddress }}?subject=Evidence:%20{{ hearing.case_reference or reference }}">{{ i18n.guidance.sendingEvidence.emailAddress }}</a></p>
+<p><a href="mailto:{{ i18n.guidance.sendingEvidence.emailAddress }}?subject=Evidence:%20{{ hearing.case_reference }}">{{ i18n.guidance.sendingEvidence.emailAddress }}</a></p>
 <h2 class="govuk-heading-s">{{ i18n.guidance.sendingEvidence.byPostHeader}}</h2>
 <p>{{ i18n.guidance.sendingEvidence.postalAddress | safe }}</p>

--- a/app/server/views/question.html
+++ b/app/server/views/question.html
@@ -23,7 +23,7 @@
 
             <h1 class="govuk-heading-l question-header">{{ question.header }}</h1>
 
-            <form action="/question/{{ question.hearingId }}/{{ question.questionId }}" method="post">
+            <form action="/question/{{ hearing.online_hearing_id }}/{{ question.questionId }}" method="post">
                 <div>
                     <p id="question-body">{{ question.body }}</p>
                     {{ govukTextarea({
@@ -45,11 +45,6 @@
                     }) }}
                 </div>
 
-                <!--
-                this remains here as fallback for non-signed in users
-                it should be removed once auth is handled properly using IDAM
-                 -->
-                {% set reference = "SC242/16/03435" %}
                 <details id="sending-evidence-guide" class="govuk-details">
                     <summary class="govuk-details__summary">
                         <span class="govuk-details__summary-text">
@@ -58,7 +53,7 @@
                     </summary>
                     <div class="govuk-details__text">
                         <p>{{ i18n.question.sendingEvidence.details.para1 }}</p>
-                        <p>{{ i18n.question.sendingEvidence.details.para2 }}<br><strong id="evidence-case-reference">{{ hearing.case_reference or reference }}</strong></p>
+                        <p>{{ i18n.question.sendingEvidence.details.para2 }}<br><strong id="evidence-case-reference">{{ hearing.case_reference }}</strong></p>
 
                         {% include "includes/sending-evidence-contact-details.html" %}
 

--- a/app/server/views/questions-completed.html
+++ b/app/server/views/questions-completed.html
@@ -10,7 +10,7 @@
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-l">{{ i18n.questionsCompleted.header }}</h1>
             <p>{{ i18n.questionsCompleted.para1}}</p>
-            <p>{{ i18n.questionsCompleted.para2Start}} {{ nextCorrespondenceDate }} {{ i18n.questionsCompleted.para2End}}</p>
+            <p>{{ i18n.questionsCompleted.para2Start}} <span id="next-contact-date">{{ nextCorrespondenceDate }}</span> {{ i18n.questionsCompleted.para2End}}</p>
             <p>
                 <a class="govuk-link" href="/logout">{{ i18n.questionsCompleted.exitService }}</a>
             </p>

--- a/app/server/views/questions-completed.html
+++ b/app/server/views/questions-completed.html
@@ -1,0 +1,19 @@
+{% extends "layout.html" %}
+
+{% block beforeContent %}
+    {{ super() }}
+    <a href="/task-list" class="govuk-back-link">{{ i18n.backLink }}</a>
+{% endblock %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">{{ i18n.questionsCompleted.header }}</h1>
+            <p>{{ i18n.questionsCompleted.para1}}</p>
+            <p>{{ i18n.questionsCompleted.para2Start}} {{ nextCorrespondenceDate }} {{ i18n.questionsCompleted.para2End}}</p>
+            <p>
+                <a class="govuk-link" href="/logout">{{ i18n.questionsCompleted.exitService }}</a>
+            </p>
+        </div>
+    </div>
+{% endblock %}

--- a/app/server/views/submit-question.html
+++ b/app/server/views/submit-question.html
@@ -6,12 +6,12 @@
 
             <h1 class="govuk-heading-l">{{ i18n.submitQuestion.title }}</h1>
 
-            <form action="/question/{{ question.hearingId }}/{{ question.questionId }}/submit" method="post">
+            <form action="/question/{{ hearing.online_hearing_id }}/{{ questionId }}/submit" method="post">
                 <div id="submit-buttons">
                     <input id="submit-answer" type="submit" name="submit" value="Confirm" class="govuk-button">
                 </div>
             </form>
-            <a class="govuk-link" href="/question/{{ question.hearingId }}/{{ question.questionId }}">{{ i18n.submitQuestion.backToQuestionText }}</a>
+            <a class="govuk-link" href="/question/{{ hearing.online_hearing_id }}/{{ questionId }}">{{ i18n.submitQuestion.backToQuestionText }}</a>
         </div>
     </div>
 {% endblock %}

--- a/app/server/views/task-list.html
+++ b/app/server/views/task-list.html
@@ -6,15 +6,13 @@
 
         <h1 class="govuk-heading-xl">{{ i18n.taskList.header }}</h1>
 
-        {% if hearing.appellant_name %}
-            <div id="appeal-details">
-                <h2 class="govuk-heading-m">
-                    <span id="appellant-name">{{ hearing.appellant_name }}</span>
-                    <a id="logout" class="govuk-link" href="/logout">Logout</a>
-                </h2>
-                <p>Appeal reference: <span id="case-reference">{{ hearing.case_reference }}</span></p>
-            </div>
-        {% endif %}
+        <div id="appeal-details">
+            <h2 class="govuk-heading-m">
+                <span id="appellant-name">{{ hearing.appellant_name }}</span>
+                <a id="logout" class="govuk-link" href="/logout">Logout</a>
+            </h2>
+            <p>Appeal reference: <span id="case-reference">{{ hearing.case_reference }}</span></p>
+        </div>
     </div>
 </div>
 
@@ -41,7 +39,7 @@
                 {% for question in questions %}
                     {% set answerState = question.answer_state %}
                     <li id="question-{{ question.question_id }}">
-                        <a class="govuk-link question-header-text" href="/question/{{ hearing.online_hearing_id or hearingId }}/{{ question.question_id }}">{{ question.question_header_text }}</a>
+                        <a class="govuk-link question-header-text" href="/question/{{ hearing.online_hearing_id }}/{{ question.question_id }}">{{ question.question_header_text }}</a>
                         {% if answerState != 'unanswered' %}
                             <span class="answer-state {{ question.answer_state }}">
                                 {{
@@ -56,11 +54,6 @@
             </ul>
         </div>
 
-        <!--
-        this remains here as fallback for non-signed in users
-        it should be removed once auth is handled properly using IDAM
-         -->
-        {% set reference = "SC242/16/03435" %}
         <h2 class="govuk-heading-s">{{ i18n.taskList.sendingEvidence.header }}</h2>
         <p>{{ i18n.taskList.sendingEvidence.intro }}</p>
 
@@ -71,7 +64,7 @@
                 </span>
             </summary>
             <div class="govuk-details__text">
-                <p>{{ i18n.taskList.sendingEvidence.details.para1 }} <strong id="evidence-case-reference">{{ hearing.case_reference or reference }}</strong></p>
+                <p>{{ i18n.taskList.sendingEvidence.details.para1 }} <strong id="evidence-case-reference">{{ hearing.case_reference }}</strong></p>
 
                 {% include "includes/sending-evidence-contact-details.html" %}
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@types/express-session": "^1.15.10",
     "@types/jquery": "^3.3.6",
     "@types/mocha": "^5.2.5",
+    "@types/moment": "^2.13.0",
     "@types/node": "^9.4.6",
     "@types/nunjucks": "^3.1.0",
     "browserify": "^16.2.2",

--- a/test/browser/2-question.test.ts
+++ b/test/browser/2-question.test.ts
@@ -1,10 +1,12 @@
 const { expect } = require('test/chai-sinon');
+const moment = require('moment');
 import { startServices } from 'test/browser/common';
 const mockDataQuestion = require('test/mock/services/question').template;
 const mockDataHearing = require('test/mock/services/hearing').template;
 const TaskListPage = require('test/page-objects/task-list');
 const QuestionPage = require('test/page-objects/question');
 const SubmitQuestionPage = require('test/page-objects/submit_question');
+const QuestionsCompletedPage = require('test/page-objects/questions-completed');
 const i18n = require('app/server/locale/en');
 const paths = require('app/server/paths');
 const config = require('config');
@@ -12,15 +14,17 @@ const config = require('config');
 const testUrl = config.get('testUrl');
 
 const sampleHearingId = '1-pending';
-const sampleQuestionId = '001';
+const sampleQuestionIdList = ['001', '002', '003']
 
 describe('Question page', () => {
   let page;
   let taskListPage;
   let questionPage;
   let submitQuestionPage;
+  let questionsCompletedPage
   let hearingId;
-  let questionId;
+  let questionIdList;
+  let firstQuestionId;
   let questionHeader;
   let questionBody;
   let caseReference;
@@ -29,14 +33,16 @@ describe('Question page', () => {
     const res = await startServices({ bootstrapData: true, performLogin: true });
     page = res.page;
     hearingId = res.cohTestData.hearingId || sampleHearingId;
-    questionId = res.cohTestData.questionId || sampleQuestionId;
-    questionHeader = res.cohTestData.questionHeader || mockDataQuestion.question_header_text({ questionId: sampleQuestionId });
-    questionBody = res.cohTestData.questionBody || mockDataQuestion.question_body_text({ questionId: sampleQuestionId });
+    questionIdList = res.cohTestData.questionIdList || sampleQuestionIdList;
+    firstQuestionId = questionIdList.shift();
+    questionHeader = res.cohTestData.questionHeader || mockDataQuestion.question_header_text({ questionId: firstQuestionId });
+    questionBody = res.cohTestData.questionBody || mockDataQuestion.question_body_text({ questionId: firstQuestionId });
     caseReference = res.ccdCase.caseReference || mockDataHearing.case_reference;
     taskListPage = new TaskListPage(page)
-    questionPage = new QuestionPage(page, hearingId, questionId);
-    submitQuestionPage = new SubmitQuestionPage(page, hearingId, questionId);
-    await taskListPage.clickQuestion(questionId);
+    questionPage = new QuestionPage(page, hearingId, firstQuestionId);
+    submitQuestionPage = new SubmitQuestionPage(page, hearingId, firstQuestionId);
+    questionsCompletedPage = new QuestionsCompletedPage(page);
+    await taskListPage.clickQuestion(firstQuestionId);
     await questionPage.screenshot('question');
   });
 
@@ -84,14 +90,14 @@ describe('Question page', () => {
     });
 
     it('displays question status as draft', async() => {
-      const answerState = await taskListPage.getElementText(`#question-${questionId} .answer-state`);
+      const answerState = await taskListPage.getElementText(`#question-${firstQuestionId} .answer-state`);
       expect(answerState).to.equal(i18n.taskList.answerState.draft.toUpperCase())
     });
   });
 
   describe('submitting an answer', () => {
     before(async() => {
-      await taskListPage.clickQuestion(questionId);
+      await taskListPage.clickQuestion(firstQuestionId);
     });
 
     it('displays the previously drafted answer', async() => {
@@ -110,10 +116,39 @@ describe('Question page', () => {
     });
 
     it('displays question status as completed', async() => {
-      const answerState = await taskListPage.getElementText(`#question-${questionId} .answer-state`);
+      const answerState = await taskListPage.getElementText(`#question-${firstQuestionId} .answer-state`);
       expect(answerState).to.equal(i18n.taskList.answerState.completed.toUpperCase())
     });
-  })
+  });
+
+  describe('submitting all answers', () => {
+    async function answerQuestion(questionId) {
+      await taskListPage.clickQuestion(questionId);
+      await questionPage.submitAnswer('A valid answer');
+      await submitQuestionPage.submit();
+    }
+
+    before('answer all but one remaining question', async() => {
+      while(questionIdList.length > 1) {
+        const questionId = questionIdList.shift();
+        await answerQuestion(questionId);
+        const answerState = await taskListPage.getElementText(`#question-${questionId} .answer-state`);
+        expect(answerState).to.equal(i18n.taskList.answerState.completed.toUpperCase())
+      }
+    });
+
+    it('is on the questions completed page after submitting the final question', async() => {
+      const questionId = questionIdList.shift();
+      await answerQuestion(questionId);
+      questionsCompletedPage.verifyPage();
+    });
+
+    it('shows the correct date for next contact', async() => {
+      const expectedDate = moment().utc().add(7, 'days').format('D MMMM YYYY');
+      const contactDate = await questionsCompletedPage.getElementText('#next-contact-date');
+      expect(contactDate).to.equal(expectedDate);
+    });
+  });
 });
 
 export {};

--- a/test/browser/bootstrap.ts
+++ b/test/browser/bootstrap.ts
@@ -23,15 +23,17 @@ async function waitForQuestionRoundIssued(hearingId, roundNum, attemptNum) {
 /* eslint-disable-next-line consistent-return */
 async function bootstrapCoh(ccdCase) {
   try {
-    const hearingId = await coh.createOnlineHearing(ccdCase.caseId)
-    const question = await coh.createQuestion(hearingId)
-    const questionId = question.question_id
-    await coh.setQuestionRoundToIssued(hearingId)
-    const questionRound = await waitForQuestionRoundIssued(hearingId, 1, null)
-    const questionHeader = questionRound.question_references[0].question_header_text
-    const questionBody = questionRound.question_references[0].question_body_text
-    const deadlineExpiryDate = questionRound.question_references[0].deadline_expiry_date
-    return { hearingId, questionId, questionHeader, questionBody, deadlineExpiryDate }
+    const hearingId = await coh.createOnlineHearing(ccdCase.caseId);
+    const questionList = await coh.createQuestions(hearingId);
+    const questionIdList = questionList.map(q => q.question_id);
+    const questionId = questionIdList[0];
+    await coh.setQuestionRoundToIssued(hearingId);
+    const questionRound = await waitForQuestionRoundIssued(hearingId, 1, null);
+    const firstQuestion = questionRound.question_references.filter(q => q.question_id === questionId).pop();
+    const questionHeader = firstQuestion.question_header_text;
+    const questionBody = firstQuestion.question_body_text;
+    const deadlineExpiryDate = firstQuestion.deadline_expiry_date;
+    return { hearingId, questionIdList, questionId, questionHeader, questionBody, deadlineExpiryDate };
   } catch (error) {
     console.log('Error bootstrapping COH with test data', error)
     return Promise.reject(error)

--- a/test/page-objects/questions-completed.js
+++ b/test/page-objects/questions-completed.js
@@ -1,0 +1,18 @@
+const { completed } = require('app/server/paths');
+const BasePage = require('test/page-objects/base');
+
+class QuestionsCompletedPage extends BasePage {
+  constructor(page) {
+    super(page);
+    this.pagePath = completed;
+  }
+
+  async submit() {
+    await Promise.all([
+      this.page.waitForNavigation(),
+      this.clickElement('#submit-answer')
+    ]);
+  }
+}
+
+module.exports = QuestionsCompletedPage;

--- a/test/unit/controllers/question.test.ts
+++ b/test/unit/controllers/question.test.ts
@@ -10,13 +10,18 @@ describe('controllers/question.js', () => {
   const next = sinon.stub();
   const req: any = {}
   const res: any = {};
+  const hearingDetails = {
+    online_hearing_id: '1',
+    case_reference: 'SC/123/456',
+    appellant_name: 'John Smith'
+  };
 
   req.params = {
     hearingId: '1',
     questionId: '2'
   };
   req.session = {
-    save: sinon.stub()
+    hearing: hearingDetails
   };
   req.body = {};
 
@@ -52,7 +57,6 @@ describe('controllers/question.js', () => {
       await getQuestion(getQuestionService)(req, res, next);
       expect(res.render).to.have.been.calledWith('question.html', {
         question: {
-          hearingId: req.params.hearingId,
           questionId: req.params.questionId,
           header: questionHeading,
           body: questionBody,

--- a/test/unit/controllers/questions-completed.test.ts
+++ b/test/unit/controllers/questions-completed.test.ts
@@ -1,0 +1,65 @@
+const { expect, sinon } = require('test/chai-sinon');
+const { setupQuestionsCompletedController, getQuestionsCompleted } = require('app/server/controllers/questions-completed');
+const moment = require('moment');
+const express = require('express');
+const paths = require('app/server/paths');
+import { Request, Response } from 'express';
+
+describe('controllers/questions-completed.js', () => {
+  let req: Request;
+  let res: Response;
+
+  beforeEach(() => {
+    req = {
+      session: {
+        questionsCompletedThisSession: true
+      }
+    } as any;
+    res = {
+      render: sinon.spy(),
+      redirect: sinon.spy()
+    } as any;
+  });
+
+  describe('getQuestionsCompleted', () => {
+    const nextCorrespondenceDate = moment().utc().add(7, 'days').format('D MMMM YYYY');
+
+    it('renders questions completed page with next date', async() => {
+      await getQuestionsCompleted(req, res);
+      expect(res.render).to.have.been.calledWith('questions-completed.html', { nextCorrespondenceDate });
+    });
+
+    it('redirects to /task-list if questions were not completed in this session', async() => {
+      delete req.session.questionsCompletedThisSession;
+      await getQuestionsCompleted(req, res);
+      expect(res.redirect).to.have.been.calledWith(paths.taskList);
+    });
+  });
+
+  describe('setupQuestionsCompletedController', () => {
+    let deps;
+    beforeEach(() => {
+      deps = {};
+      sinon.stub(express, 'Router').returns({
+        get: sinon.stub(),
+        post: sinon.stub()
+      });
+    });
+
+    afterEach(() => {
+      express.Router.restore();
+    });
+
+    it('calls router.get with the path and middleware', () => {
+      setupQuestionsCompletedController(deps);
+      // eslint-disable-next-line new-cap
+      expect(express.Router().get).to.have.been.calledWith(paths.completed);
+    });
+
+    it('returns the router', () => {
+      const controller = setupQuestionsCompletedController(deps);
+      // eslint-disable-next-line new-cap
+      expect(controller).to.equal(express.Router());
+    });
+  });
+});

--- a/test/unit/controllers/submit_question.test.ts
+++ b/test/unit/controllers/submit_question.test.ts
@@ -7,13 +7,20 @@ const express = require('express');
 
 describe('controllers/submit_question.js', () => {
   const next = sinon.stub();
-  const req:any = {}; 
-  const res:any = {};
+  const req: any = {};
+  const res: any = {};
   const hearingDetails = {
     online_hearing_id: '1',
     case_reference: 'SC/123/456',
     appellant_name: 'John Smith'
   };
+  const questions = answerState => [
+    {
+      question_id: '001',
+      question_header_text: 'How do you interact with people?',
+      answer_state: answerState
+    }
+  ];
 
   req.params = {
     questionId: '2'
@@ -27,6 +34,8 @@ describe('controllers/submit_question.js', () => {
   res.redirect = sinon.stub();
 
   beforeEach(() => {
+    res.render.reset();
+    res.redirect.reset();
     sinon.stub(appInsights, 'trackException');
   });
 
@@ -44,9 +53,10 @@ describe('controllers/submit_question.js', () => {
   });
 
   describe('postSubmitAnswer', () => {
-    it('should call res.redirect when submitting an answer and there are no errors', async() => {
+    it('redirects to /task-list', async() => {
       const submitAnswerService = () => Promise.resolve();
-      await postSubmitAnswer(submitAnswerService)(req, res, next);
+      const getAllQuestionsService = () => Promise.resolve({ questions: questions('draft') });
+      await postSubmitAnswer(submitAnswerService, getAllQuestionsService)(req, res, next);
       expect(res.redirect).to.have.been.calledWith(paths.taskList);
     });
 
@@ -56,6 +66,26 @@ describe('controllers/submit_question.js', () => {
       await postSubmitAnswer(submitAnswerService)(req, res, next);
       expect(appInsights.trackException).to.have.been.calledOnce.calledWith(error);
       expect(next).to.have.been.calledWith(error);
+    });
+
+    describe('when all questions are submitted', () => {
+      let submitAnswerService;
+      let getAllQuestionsService;
+
+      beforeEach(() => {
+        submitAnswerService = () => Promise.resolve();
+        getAllQuestionsService = () => Promise.resolve({ questions: questions('submitted') });
+      });
+
+      it('sets questionsCompletedThisSession on the session', async() => {
+        await postSubmitAnswer(submitAnswerService, getAllQuestionsService)(req, res, next);
+        expect(req.session).to.have.property('questionsCompletedThisSession', true);
+      });
+
+      it('redirects to questions completed if all are /questions-completed', async() => {
+        await postSubmitAnswer(submitAnswerService, getAllQuestionsService)(req, res, next);
+        expect(res.redirect).to.have.been.calledWith(paths.completed);
+      });
     });
   });
 

--- a/test/unit/controllers/submit_question.test.ts
+++ b/test/unit/controllers/submit_question.test.ts
@@ -9,10 +9,18 @@ describe('controllers/submit_question.js', () => {
   const next = sinon.stub();
   const req:any = {}; 
   const res:any = {};
+  const hearingDetails = {
+    online_hearing_id: '1',
+    case_reference: 'SC/123/456',
+    appellant_name: 'John Smith'
+  };
 
   req.params = {
-    hearingId: '1',
     questionId: '2'
+  };
+
+  req.session = {
+    hearing: hearingDetails
   };
 
   res.render = sinon.stub();
@@ -28,12 +36,9 @@ describe('controllers/submit_question.js', () => {
 
   describe('getSubmitQuestion', () => {
     it('should call render with the template and hearing/question ids', () => {
-      getSubmitQuestion()(req, res);
+      getSubmitQuestion(req, res);
       expect(res.render).to.have.been.calledWith('submit-question.html', {
-        question: {
-          hearingId: req.params.hearingId,
-          questionId: req.params.questionId
-        }
+        questionId: req.params.questionId
       });
     });
   });

--- a/test/unit/controllers/taskList.test.ts
+++ b/test/unit/controllers/taskList.test.ts
@@ -56,7 +56,6 @@ describe('controllers/taskList.js', () => {
       getAllQuestionsService = () => Promise.resolve({ questions, deadline_expiry_date: inputDeadline });
       await getTaskList(getAllQuestionsService)(req, res, next);
       expect(res.render).to.have.been.calledWith('task-list.html', {
-        hearingId: '1',
         questions,
         deadlineExpiryDate: {
           extendable: true,
@@ -71,7 +70,6 @@ describe('controllers/taskList.js', () => {
       getAllQuestionsService = () => Promise.resolve({ questions, deadline_expiry_date: inputDeadline });
       await getTaskList(getAllQuestionsService)(req, res, next);
       expect(res.render).to.have.been.calledWith('task-list.html', {
-        hearingId: '1',
         questions,
         deadlineExpiryDate: {
           extendable: false,
@@ -88,7 +86,6 @@ describe('controllers/taskList.js', () => {
       getAllQuestionsService = () => Promise.resolve({ questions, deadline_expiry_date: inputExpiredDeadline });
       await getTaskList(getAllQuestionsService)(req, res, next);
       expect(res.render).to.have.been.calledWith('task-list.html', {
-        hearingId: '1',
         questions,
         deadlineExpiryDate: {
           extendable: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -163,6 +163,12 @@
   version "5.2.5"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.5.tgz#8a4accfc403c124a0bafe8a9fc61a05ec1032073"
 
+"@types/moment@^2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@types/moment/-/moment-2.13.0.tgz#604ebd189bc3bc34a1548689404e61a2a4aac896"
+  dependencies:
+    moment "*"
+
 "@types/node@*":
   version "10.9.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.2.tgz#f0ab8dced5cd6c56b26765e1c0d9e4fdcc9f2a00"
@@ -3693,7 +3699,7 @@ module-deps@^6.0.0:
     through2 "^2.0.0"
     xtend "^4.0.0"
 
-moment@^2.18.1, moment@^2.19.3:
+moment@*, moment@^2.18.1, moment@^2.19.3:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 


### PR DESCRIPTION
**Tidying up use of hearing ID and case reference**
* since we now enforce "login" using email address there is no need to get hearing ID from the querystring
* case reference will set in the session, a default is no longer required

**Displaying questions completed page when all questions are submitted**
* adding moment types
* amending submit question page to send user to new page if all questions are submitted
* at this stage, to be safe, the questions are requested from the backend when required

**Functional testing for questions completed page**
* adjusting tests to be aware of multiple questions
* COH data bootstrap now creates 3 questions to match local stubs

**Screenshot**
<img width="667" alt="screen shot 2018-09-06 at 15 43 18" src="https://user-images.githubusercontent.com/1334068/45164968-a6487f00-b1eb-11e8-9742-26ed01ce42ec.png">
