### PR TITLE
[PREVIEW] Cleaner question urls

### DIFF
--- a/app/server/controllers/question.ts
+++ b/app/server/controllers/question.ts
@@ -48,7 +48,7 @@ function postAnswer(updateAnswerService) {
       try {
         await updateAnswerService(hearingId, questionId, 'draft', answerText);
         if (req.body.submit) {
-          res.redirect(`${Paths.question}/${hearingId}/${questionId}/submit`);
+          res.redirect(`${Paths.question}/${questionId}/submit`);
         } else {
           res.redirect(Paths.taskList);
         }
@@ -63,8 +63,9 @@ function postAnswer(updateAnswerService) {
 function setupQuestionController(deps) {
   // eslint-disable-next-line new-cap
   const router = Router();
-  router.get('/:hearingId/:questionId', deps.prereqMiddleware, getQuestion(deps.getQuestionService));
-  router.post('/:hearingId/:questionId', deps.prereqMiddleware, postAnswer(deps.saveAnswerService));
+  router.get('/:questionId', deps.prereqMiddleware, getQuestion(deps.getQuestionService));
+  router.post('/:questionId', deps.prereqMiddleware, postAnswer(deps.saveAnswerService));
+  router.post('/:questionId', deps.prereqMiddleware, postAnswer(deps.saveAnswerService));
   return router;
 }
 

--- a/app/server/controllers/submit-question.ts
+++ b/app/server/controllers/submit-question.ts
@@ -35,8 +35,8 @@ function postSubmitAnswer(submitAnswerService: any, getAllQuestionsService: any)
 function setupSubmitQuestionController(deps: any) {
   // eslint-disable-next-line new-cap
   const router = Router();
-  router.get(`${Paths.question}/:hearingId/:questionId/submit`, deps.prereqMiddleware, getSubmitQuestion);
-  router.post(`${Paths.question}/:hearingId/:questionId/submit`, deps.prereqMiddleware, postSubmitAnswer(deps.submitAnswerService, deps.getAllQuestionsService));
+  router.get(`${Paths.question}/:questionId/submit`, deps.prereqMiddleware, getSubmitQuestion);
+  router.post(`${Paths.question}/:questionId/submit`, deps.prereqMiddleware, postSubmitAnswer(deps.submitAnswerService, deps.getAllQuestionsService));
   return router;
 }
 

--- a/app/server/controllers/submit-question.ts
+++ b/app/server/controllers/submit-question.ts
@@ -1,20 +1,29 @@
 import { Router, Request, Response, NextFunction } from "express";
 import * as AppInsights from 'app/server/app-insights';
 import * as Paths from 'app/server/paths';
+import { getCurrentQuestion } from 'app/server/controllers/question'
 
 const getSubmittedQuestionCount = (questions: any) => questions.filter((q: any) => q.answer_state === 'submitted').length;
 
 function getSubmitQuestion(req: Request, res: Response) {
-  const questionId = req.params.questionId;
-  res.render('submit-question.html', { questionId });
+  const questionOrdinal = parseInt(req.params.questionOrdinal, 10);
+  if (!req.session.questions) {
+    return res.redirect(Paths.taskList);
+  }
+  const currentQuestion = req.session.questions.find(q => q.question_ordinal === questionOrdinal);
+  res.render('submit-question.html', currentQuestion);
 }
 
 function postSubmitAnswer(submitAnswerService: any, getAllQuestionsService: any) {
   return async(req: Request, res: Response, next: NextFunction) => {
+    const currentQuestion = getCurrentQuestion(req);
+    if (!currentQuestion) {
+      return res.redirect(Paths.taskList);
+    }
     const hearingId = req.session.hearing.online_hearing_id;
-    const questionId = req.params.questionId;
+
     try {
-      await submitAnswerService(hearingId, questionId);
+      await submitAnswerService(hearingId, currentQuestion.question_id);
 
       const response = await getAllQuestionsService(hearingId);
       const totalQuestionCount = response.questions.length;
@@ -35,8 +44,8 @@ function postSubmitAnswer(submitAnswerService: any, getAllQuestionsService: any)
 function setupSubmitQuestionController(deps: any) {
   // eslint-disable-next-line new-cap
   const router = Router();
-  router.get(`${Paths.question}/:questionId/submit`, deps.prereqMiddleware, getSubmitQuestion);
-  router.post(`${Paths.question}/:questionId/submit`, deps.prereqMiddleware, postSubmitAnswer(deps.submitAnswerService, deps.getAllQuestionsService));
+  router.get(`${Paths.question}/:questionOrdinal/submit`, deps.prereqMiddleware, getSubmitQuestion);
+  router.post(`${Paths.question}/:questionOrdinal/submit`, deps.prereqMiddleware, postSubmitAnswer(deps.submitAnswerService, deps.getAllQuestionsService));
   return router;
 }
 

--- a/app/server/controllers/task-list.ts
+++ b/app/server/controllers/task-list.ts
@@ -18,7 +18,7 @@ function getTaskList(getAllQuestionsService: any) {
   return async(req: Request, res: Response, next: NextFunction) => {
     const hearing = req.session.hearing;
     try {
-      const response = await getAllQuestionsService(hearing.online_hearing_id);
+      const response = await getAllQuestionsService.getAllQuestions(hearing.online_hearing_id);
 
       req.session.hearing.deadline = response.deadline_expiry_date;
       req.session.questions = response.questions;

--- a/app/server/controllers/task-list.ts
+++ b/app/server/controllers/task-list.ts
@@ -21,8 +21,9 @@ function getTaskList(getAllQuestionsService: any) {
       const response = await getAllQuestionsService(hearing.online_hearing_id);
 
       req.session.hearing.deadline = response.deadline_expiry_date;
+      req.session.questions = response.questions;
       req.session.hearing.extensionCount = response.deadline_extension_count;
-      
+
       const totalQuestionCount = response.questions.length;
       const allQuestionsSubmitted = totalQuestionCount === getSubmittedQuestionCount(response.questions);
       const deadlineDetails = processDeadline(response.deadline_expiry_date, allQuestionsSubmitted);

--- a/app/server/routes.ts
+++ b/app/server/routes.ts
@@ -15,7 +15,7 @@ import { setupDecisionController } from './controllers/decision';
 const router = express.Router();
 
 const getQuestionService = require('app/server/services/getQuestion');
-const getAllQuestionsService = require('app/server/services/getAllQuestions');
+import * as getAllQuestionsService from 'app/server/services/getAllQuestions';
 import { getOnlineHearing } from 'app/server/services/getOnlineHearing';
 const { saveAnswer: saveAnswerService, submitAnswer: submitAnswerService } = require('app/server/services/updateAnswer');
 
@@ -23,6 +23,7 @@ import { extendDeadline as extendDeadlineService } from 'app/server/services/ext
 const prereqMiddleware = [ensureAuthenticated, checkDecision];
 
 const questionController = setupQuestionController({
+  getAllQuestionsService,
   getQuestionService,
   saveAnswerService,
   prereqMiddleware

--- a/app/server/services/getAllQuestions.ts
+++ b/app/server/services/getAllQuestions.ts
@@ -1,16 +1,44 @@
+import { Request } from 'express'
 const config = require('config');
 const request = require('superagent');
 
 const apiUrl = config.get('api.url');
 
-async function getQuestion(hearingId) {
+interface QuestionSummary {
+  question_id: string,
+  question_ordinal: number,
+  question_header_text: string,
+  answer_state: string
+}
+
+interface QuestionRound {
+  deadline_expiry_date: string
+  questions: QuestionSummary[]
+}
+
+async function getAllQuestions(hearingId): Promise<QuestionRound> {
   try {
-    const response = await request
-      .get(`${apiUrl}/continuous-online-hearings/${hearingId}`);
+    const response = await request.get(`${apiUrl}/continuous-online-hearings/${hearingId}`);
     return Promise.resolve(response.body);
   } catch (error) {
     return Promise.reject(error);
   }
 }
 
-export = getQuestion;
+function getQuestionIdFromOrdinal(req: Request): string {
+  const questions: QuestionSummary[] = req.session.questions;
+  if (!questions) {
+    return undefined;
+  }
+  const questionOrdinal: number = parseInt(req.params.questionOrdinal, 10);
+  const currentQuestion: QuestionSummary = questions.find(q => q.question_ordinal === questionOrdinal);
+  if (!currentQuestion) {
+    return undefined;
+  }
+  return currentQuestion.question_id;
+}
+
+export {
+  getAllQuestions,
+  getQuestionIdFromOrdinal
+}

--- a/app/server/views/question/answer-form.html
+++ b/app/server/views/question/answer-form.html
@@ -1,4 +1,4 @@
-<form action="/question/{{ question.questionId }}" method="post">
+<form action="/question/{{ question.questionOrdinal }}" method="post">
   <div>
     {{ govukTextarea({
           id: 'question-field',

--- a/app/server/views/question/answer-form.html
+++ b/app/server/views/question/answer-form.html
@@ -1,4 +1,4 @@
-<form action="/question/{{ hearing.online_hearing_id }}/{{ question.questionId }}" method="post">
+<form action="/question/{{ question.questionId }}" method="post">
   <div>
     {{ govukTextarea({
           id: 'question-field',

--- a/app/server/views/submit-question.html
+++ b/app/server/views/submit-question.html
@@ -6,12 +6,12 @@
 
             <h1 class="govuk-heading-l">{{ i18n.submitQuestion.title }}</h1>
 
-            <form action="/question/{{ question_ordinal }}/submit" method="post">
+            <form action="/question/{{ questionOrdinal }}/submit" method="post">
                 <div id="submit-buttons">
                     <input id="submit-answer" type="submit" name="submit" value="Confirm" class="govuk-button">
                 </div>
             </form>
-            <a class="govuk-link" href="/question/{{ question_ordinal }}">{{ i18n.submitQuestion.backToQuestionText }}</a>
+            <a class="govuk-link" href="/question/{{ questionOrdinal }}">{{ i18n.submitQuestion.backToQuestionText }}</a>
         </div>
     </div>
 {% endblock %}

--- a/app/server/views/submit-question.html
+++ b/app/server/views/submit-question.html
@@ -6,12 +6,12 @@
 
             <h1 class="govuk-heading-l">{{ i18n.submitQuestion.title }}</h1>
 
-            <form action="/question/{{ hearing.online_hearing_id }}/{{ questionId }}/submit" method="post">
+            <form action="/question/{{ questionId }}/submit" method="post">
                 <div id="submit-buttons">
                     <input id="submit-answer" type="submit" name="submit" value="Confirm" class="govuk-button">
                 </div>
             </form>
-            <a class="govuk-link" href="/question/{{ hearing.online_hearing_id }}/{{ questionId }}">{{ i18n.submitQuestion.backToQuestionText }}</a>
+            <a class="govuk-link" href="/question/{{ questionId }}">{{ i18n.submitQuestion.backToQuestionText }}</a>
         </div>
     </div>
 {% endblock %}

--- a/app/server/views/submit-question.html
+++ b/app/server/views/submit-question.html
@@ -6,12 +6,12 @@
 
             <h1 class="govuk-heading-l">{{ i18n.submitQuestion.title }}</h1>
 
-            <form action="/question/{{ questionId }}/submit" method="post">
+            <form action="/question/{{ question_ordinal }}/submit" method="post">
                 <div id="submit-buttons">
                     <input id="submit-answer" type="submit" name="submit" value="Confirm" class="govuk-button">
                 </div>
             </form>
-            <a class="govuk-link" href="/question/{{ questionId }}">{{ i18n.submitQuestion.backToQuestionText }}</a>
+            <a class="govuk-link" href="/question/{{ question_ordinal }}">{{ i18n.submitQuestion.backToQuestionText }}</a>
         </div>
     </div>
 {% endblock %}

--- a/app/server/views/task-list.html
+++ b/app/server/views/task-list.html
@@ -27,7 +27,7 @@
                 {% for question in questions %}
                     {% set answerState = question.answer_state %}
                     <li id="question-{{ question.question_id }}">
-                        <a class="govuk-link question-header-text" href="/question/{{ question.question_id }}">{{ question.question_header_text }}</a>
+                        <a class="govuk-link question-header-text" href="/question/{{ question.question_ordinal }}">{{ question.question_header_text }}</a>
                         {% if answerState != 'unanswered' %}
                             <span class="answer-state {{ question.answer_state }}">
                                 {{

--- a/app/server/views/task-list.html
+++ b/app/server/views/task-list.html
@@ -27,7 +27,7 @@
                 {% for question in questions %}
                     {% set answerState = question.answer_state %}
                     <li id="question-{{ question.question_id }}">
-                        <a class="govuk-link question-header-text" href="/question/{{ hearing.online_hearing_id }}/{{ question.question_id }}">{{ question.question_header_text }}</a>
+                        <a class="govuk-link question-header-text" href="/question/{{ question.question_id }}">{{ question.question_header_text }}</a>
                         {% if answerState != 'unanswered' %}
                             <span class="answer-state {{ question.answer_state }}">
                                 {{

--- a/test/accessibility/runPa11y.ts
+++ b/test/accessibility/runPa11y.ts
@@ -21,7 +21,7 @@ const pa11yTest = pa11y({
     .govuk-skip-link, .govuk-footer__link`
 });
 
-const accessibilityPages = [`${Paths.question}/121/62`];
+const accessibilityPages = [`${Paths.question}/1`];
 
 accessibilityPages.forEach(page => {
   describe(`Running Accessibility tests for: ${page}`, () => {

--- a/test/browser/1-task-list.test.ts
+++ b/test/browser/1-task-list.test.ts
@@ -12,12 +12,14 @@ const testUrl = config.get('testUrl');
 
 const sampleHearingId = '1-pending';
 const sampleQuestionId = '001';
+const sampleQuestionOrdinal = '1';
 
 describe('Task list page', () => {
   let page;
   let taskListPage;
   let hearingId;
   let questionId;
+  let questionOrdinal;
   let questionHeader;
   let caseReference;
   let deadlineExpiryDateFormatted;
@@ -27,6 +29,7 @@ describe('Task list page', () => {
     page = res.page;
     hearingId = res.cohTestData.hearingId || sampleHearingId;
     questionId = res.cohTestData.questionId || sampleQuestionId;
+    questionOrdinal = res.cohTestData.questionOrdinal || sampleQuestionOrdinal;
     questionHeader = res.cohTestData.questionHeader || mockDataQuestions.questions({ sampleHearingId })[0].question_header_text;
     caseReference = res.ccdCase.caseReference || mockDataHearing.case_reference;
     const deadlineExpiryDate = res.cohTestData.deadlineExpiryDate || mockDataQuestions.deadline_expiry_date({ sampleHearingId });
@@ -75,7 +78,7 @@ describe('Task list page', () => {
   it('redirects to the question page for that question', async() => {
     await taskListPage.clickQuestion(questionId);
     expect(taskListPage.getCurrentUrl())
-      .to.equal(`${testUrl}${Paths.question}/${questionId}`);
+      .to.equal(`${testUrl}${Paths.question}/${questionOrdinal}`);
   });
 });
 

--- a/test/browser/1-task-list.test.ts
+++ b/test/browser/1-task-list.test.ts
@@ -75,7 +75,7 @@ describe('Task list page', () => {
   it('redirects to the question page for that question', async() => {
     await taskListPage.clickQuestion(questionId);
     expect(taskListPage.getCurrentUrl())
-      .to.equal(`${testUrl}${Paths.question}/${hearingId}/${questionId}`);
+      .to.equal(`${testUrl}${Paths.question}/${questionId}`);
   });
 });
 

--- a/test/browser/3-question.test.ts
+++ b/test/browser/3-question.test.ts
@@ -14,7 +14,6 @@ import * as moment from 'moment';
 
 const testUrl = config.get('testUrl');
 
-const sampleHearingId = '1-pending';
 const sampleQuestionIdList = ['001', '002', '003']
 
 describe('Question page', () => {
@@ -23,7 +22,6 @@ describe('Question page', () => {
   let questionPage;
   let submitQuestionPage;
   let questionsCompletedPage
-  let hearingId;
   let questionIdList;
   let firstQuestionId;
   let questionHeader;
@@ -33,15 +31,14 @@ describe('Question page', () => {
   before('start services and bootstrap data in CCD/COH', async() => {
     const res = await startServices({ bootstrapData: true, performLogin: true });
     page = res.page;
-    hearingId = res.cohTestData.hearingId || sampleHearingId;
     questionIdList = res.cohTestData.questionIdList || sampleQuestionIdList;
     firstQuestionId = questionIdList.shift();
     questionHeader = res.cohTestData.questionHeader || mockDataQuestion.question_header_text({ questionId: firstQuestionId });
     questionBody = res.cohTestData.questionBody || mockDataQuestion.question_body_text({ questionId: firstQuestionId });
     caseReference = res.ccdCase.caseReference || mockDataHearing.case_reference;
     taskListPage = new TaskListPage(page);
-    questionPage = new QuestionPage(page, hearingId, firstQuestionId);
-    submitQuestionPage = new SubmitQuestionPage(page, hearingId, firstQuestionId);
+    questionPage = new QuestionPage(page, firstQuestionId);
+    submitQuestionPage = new SubmitQuestionPage(page, firstQuestionId);
     questionsCompletedPage = new QuestionsCompletedPage(page);
     await taskListPage.clickQuestion(firstQuestionId);
     await questionPage.screenshot('question');

--- a/test/browser/3-question.test.ts
+++ b/test/browser/3-question.test.ts
@@ -15,6 +15,7 @@ import * as moment from 'moment';
 const testUrl = config.get('testUrl');
 
 const sampleQuestionIdList = ['001', '002', '003']
+const sampleQuestionOrdinal = '1';
 
 describe('Question page', () => {
   let page;
@@ -23,6 +24,7 @@ describe('Question page', () => {
   let submitQuestionPage;
   let questionsCompletedPage
   let questionIdList;
+  let questionOrdinal;
   let firstQuestionId;
   let questionHeader;
   let questionBody;
@@ -33,12 +35,13 @@ describe('Question page', () => {
     page = res.page;
     questionIdList = res.cohTestData.questionIdList || sampleQuestionIdList;
     firstQuestionId = questionIdList.shift();
+    questionOrdinal = res.cohTestData.questionOrdinal || sampleQuestionOrdinal;
     questionHeader = res.cohTestData.questionHeader || mockDataQuestion.question_header_text({ questionId: firstQuestionId });
     questionBody = res.cohTestData.questionBody || mockDataQuestion.question_body_text({ questionId: firstQuestionId });
     caseReference = res.ccdCase.caseReference || mockDataHearing.case_reference;
     taskListPage = new TaskListPage(page);
-    questionPage = new QuestionPage(page, firstQuestionId);
-    submitQuestionPage = new SubmitQuestionPage(page, firstQuestionId);
+    questionPage = new QuestionPage(page, questionOrdinal);
+    submitQuestionPage = new SubmitQuestionPage(page, questionOrdinal);
     questionsCompletedPage = new QuestionsCompletedPage(page);
     await taskListPage.clickQuestion(firstQuestionId);
     await questionPage.screenshot('question');

--- a/test/browser/bootstrap.ts
+++ b/test/browser/bootstrap.ts
@@ -49,10 +49,11 @@ async function bootstrapCoh(ccdCase) {
     await coh.setQuestionRoundToIssued(hearingId);
     const questionRound = await waitForQuestionRoundIssued(hearingId, 1, null);
     const firstQuestion = questionRound.question_references.filter(q => q.question_id === questionId).pop();
+    const questionOrdinal = firstQuestion.question_ordinal;
     const questionHeader = firstQuestion.question_header_text;
     const questionBody = firstQuestion.question_body_text;
     const deadlineExpiryDate = firstQuestion.deadline_expiry_date;
-    return { hearingId, questionIdList, questionId, questionHeader, questionBody, deadlineExpiryDate };
+    return { hearingId, questionIdList, questionId, questionOrdinal, questionHeader, questionBody, deadlineExpiryDate };
   } catch (error) {
     console.log('Error bootstrapping COH with test data', error)
     return Promise.reject(error)

--- a/test/mock/cor-backend/services/all-questions.js
+++ b/test/mock/cor-backend/services/all-questions.js
@@ -37,14 +37,17 @@ module.exports = {
     questions: params => [
       {
         question_id: '001',
+        question_ordinal: 1,
         question_header_text: questionData['001'].header,
         answer_state: answerState('001', params.onlineHearingId)
       }, {
         question_id: '002',
+        question_ordinal: 2,
         question_header_text: questionData['002'].header,
         answer_state: answerState('002', params.onlineHearingId)
       }, {
         question_id: '003',
+        question_ordinal: 3,
         question_header_text: questionData['003'].header,
         answer_state: answerState('003', params.onlineHearingId)
       }

--- a/test/mock/cor-backend/services/question.js
+++ b/test/mock/cor-backend/services/question.js
@@ -22,6 +22,7 @@ module.exports = {
   cache: false,
   template: {
     question_id: params => `${params.questionId}`,
+    question_ordinal: params => parseInt(params.questionId.replace('00', ''), 10),
     question_header_text: params => questionData[params.questionId].header,
     question_body_text: params => questionData[params.questionId].body,
     answer: params => getCachedAnswer(params.questionId),

--- a/test/page-objects/question.ts
+++ b/test/page-objects/question.ts
@@ -2,9 +2,9 @@ const { question } = require('app/server/paths');
 import { BasePage } from 'test/page-objects/base';
 
 export class QuestionPage extends BasePage {
-  constructor(page, hearingId, questionId) {
+  constructor(page, questionId) {
     super(page);
-    this.pagePath = `${question}/${hearingId}/${questionId}`;
+    this.pagePath = `${question}/${questionId}`;
   }
 
   async answer(answer, submit) {

--- a/test/page-objects/question.ts
+++ b/test/page-objects/question.ts
@@ -2,9 +2,9 @@ const { question } = require('app/server/paths');
 import { BasePage } from 'test/page-objects/base';
 
 export class QuestionPage extends BasePage {
-  constructor(page, questionId) {
+  constructor(page, questionOrdinal) {
     super(page);
-    this.pagePath = `${question}/${questionId}`;
+    this.pagePath = `${question}/${questionOrdinal}`;
   }
 
   async answer(answer, submit) {

--- a/test/page-objects/submit-question.ts
+++ b/test/page-objects/submit-question.ts
@@ -2,9 +2,9 @@ const { question } = require('app/server/paths');
 import { BasePage } from 'test/page-objects/base';
 
 export class SubmitQuestionPage extends BasePage {
-  constructor(page, questionId) {
+  constructor(page, questionOrdinal) {
     super(page);
-    this.pagePath = `${question}/${questionId}/submit`;
+    this.pagePath = `${question}/${questionOrdinal}/submit`;
   }
 
   async submit() {

--- a/test/page-objects/submit-question.ts
+++ b/test/page-objects/submit-question.ts
@@ -2,9 +2,9 @@ const { question } = require('app/server/paths');
 import { BasePage } from 'test/page-objects/base';
 
 export class SubmitQuestionPage extends BasePage {
-  constructor(page, hearingId, questionId) {
+  constructor(page, questionId) {
     super(page);
-    this.pagePath = `${question}/${hearingId}/${questionId}/submit`;
+    this.pagePath = `${question}/${questionId}/submit`;
   }
 
   async submit() {

--- a/test/unit/controllers/question.test.ts
+++ b/test/unit/controllers/question.test.ts
@@ -18,7 +18,6 @@ describe('controllers/question.js', () => {
   };
 
   req.params = {
-    hearingId: '1',
     questionId: '2'
   };
   req.session = {
@@ -107,7 +106,7 @@ describe('controllers/question.js', () => {
       postAnswerService = () => Promise.resolve();
       await postAnswer(postAnswerService)(req, res, next);
       expect(res.redirect).to.have.been.calledWith(
-        `${Paths.question}/${req.params.hearingId}/${req.params.questionId}/submit`
+        `${Paths.question}/${req.params.questionId}/submit`
       );
     });
 
@@ -154,13 +153,13 @@ describe('controllers/question.js', () => {
     it('calls router.get with the path and middleware', () => {
       setupQuestionController(deps);
       // eslint-disable-next-line new-cap
-      expect(express.Router().get).to.have.been.calledWith('/:hearingId/:questionId');
+      expect(express.Router().get).to.have.been.calledWith('/:questionId');
     });
 
     it('calls router.post with the path and middleware', () => {
       setupQuestionController(deps);
       // eslint-disable-next-line new-cap
-      expect(express.Router().post).to.have.been.calledWith('/:hearingId/:questionId');
+      expect(express.Router().post).to.have.been.calledWith('/:questionId');
     });
 
     it('returns the router', () => {

--- a/test/unit/controllers/submit-question.test.ts
+++ b/test/unit/controllers/submit-question.test.ts
@@ -1,4 +1,5 @@
 const { getSubmitQuestion, postSubmitAnswer, setupSubmitQuestionController } = require('app/server/controllers/submit-question.ts');
+const mockData = require('test/mock/cor-backend/services/all-questions').template;
 const { expect, sinon } = require('test/chai-sinon');
 const { INTERNAL_SERVER_ERROR } = require('http-status-codes');
 import * as AppInsights from 'app/server/app-insights';
@@ -23,11 +24,12 @@ describe('controllers/submit-question', () => {
   ];
 
   req.params = {
-    questionId: '2'
+    questionOrdinal: '1'
   };
 
   req.session = {
-    hearing: hearingDetails
+    hearing: hearingDetails,
+    questions: mockData.questions({})
   };
 
   res.render = sinon.stub();
@@ -46,9 +48,7 @@ describe('controllers/submit-question', () => {
   describe('getSubmitQuestion', () => {
     it('should call render with the template and hearing/question ids', () => {
       getSubmitQuestion(req, res);
-      expect(res.render).to.have.been.calledWith('submit-question.html', {
-        questionId: req.params.questionId
-      });
+      expect(res.render).to.have.been.calledWith('submit-question.html', req.session.questions[0]);
     });
   });
 
@@ -108,13 +108,13 @@ describe('controllers/submit-question', () => {
     it('calls router.get with the path and middleware', () => {
       setupSubmitQuestionController(deps);
       // eslint-disable-next-line new-cap
-      expect(express.Router().get).to.have.been.calledWith(`${Paths.question}/:questionId/submit`);
+      expect(express.Router().get).to.have.been.calledWith(`${Paths.question}/:questionOrdinal/submit`);
     });
 
     it('calls router.post with the path and middleware', () => {
       setupSubmitQuestionController(deps);
       // eslint-disable-next-line new-cap
-      expect(express.Router().post).to.have.been.calledWith(`${Paths.question}/:questionId/submit`);
+      expect(express.Router().post).to.have.been.calledWith(`${Paths.question}/:questionOrdinal/submit`);
     });
 
     it('returns the router', () => {

--- a/test/unit/controllers/submit-question.test.ts
+++ b/test/unit/controllers/submit-question.test.ts
@@ -108,13 +108,13 @@ describe('controllers/submit-question', () => {
     it('calls router.get with the path and middleware', () => {
       setupSubmitQuestionController(deps);
       // eslint-disable-next-line new-cap
-      expect(express.Router().get).to.have.been.calledWith(`${Paths.question}/:hearingId/:questionId/submit`);
+      expect(express.Router().get).to.have.been.calledWith(`${Paths.question}/:questionId/submit`);
     });
 
     it('calls router.post with the path and middleware', () => {
       setupSubmitQuestionController(deps);
       // eslint-disable-next-line new-cap
-      expect(express.Router().post).to.have.been.calledWith(`${Paths.question}/:hearingId/:questionId/submit`);
+      expect(express.Router().post).to.have.been.calledWith(`${Paths.question}/:questionId/submit`);
     });
 
     it('returns the router', () => {

--- a/test/unit/controllers/task-list.test.ts
+++ b/test/unit/controllers/task-list.test.ts
@@ -42,7 +42,7 @@ describe('controllers/task-list.js', () => {
     const expectedDeadline = deadline.format();
 
     beforeEach(() => {
-      getAllQuestionsService = null;
+      getAllQuestionsService = {};
       questions = [
         {
           question_id: '001',
@@ -53,7 +53,7 @@ describe('controllers/task-list.js', () => {
     });
 
     it('should call render with the template and the list of questions and deadline details', async() => {
-      getAllQuestionsService = () => Promise.resolve({ questions, deadline_expiry_date: inputDeadline });
+      getAllQuestionsService.getAllQuestions = () => Promise.resolve({ questions, deadline_expiry_date: inputDeadline });
       await getTaskList(getAllQuestionsService)(req, res, next);
       expect(res.render).to.have.been.calledWith('task-list.html', {
         questions,
@@ -67,7 +67,7 @@ describe('controllers/task-list.js', () => {
 
     it('should call render with deadline status complete when all questions submitted', async() => {
       questions[0].answer_state = 'submitted';
-      getAllQuestionsService = () => Promise.resolve({ questions, deadline_expiry_date: inputDeadline });
+      getAllQuestionsService.getAllQuestions = () => Promise.resolve({ questions, deadline_expiry_date: inputDeadline });
       await getTaskList(getAllQuestionsService)(req, res, next);
       expect(res.render).to.have.been.calledWith('task-list.html', {
         questions,
@@ -83,7 +83,7 @@ describe('controllers/task-list.js', () => {
       const expiredDeadline = moment().utc().subtract(1, 'day');
       const inputExpiredDeadline = expiredDeadline.format();
       const expectedExpiredDeadline = expiredDeadline.format();
-      getAllQuestionsService = () => Promise.resolve({ questions, deadline_expiry_date: inputExpiredDeadline });
+      getAllQuestionsService.getAllQuestions = () => Promise.resolve({ questions, deadline_expiry_date: inputExpiredDeadline });
       await getTaskList(getAllQuestionsService)(req, res, next);
       expect(res.render).to.have.been.calledWith('task-list.html', {
         questions,
@@ -97,7 +97,7 @@ describe('controllers/task-list.js', () => {
 
     it('should call next and appInsights with the error when there is one', async() => {
       const error = { value: INTERNAL_SERVER_ERROR, reason: 'Server Error' };
-      getAllQuestionsService = () => Promise.reject(error);
+      getAllQuestionsService.getAllQuestions = () => Promise.reject(error);
       await getTaskList(getAllQuestionsService)(req, res, next);
       expect(AppInsights.trackException).to.have.been.calledOnce.calledWith(error);
       expect(next).to.have.been.calledWith(error);

--- a/test/unit/services/getAllQuestions.test.ts
+++ b/test/unit/services/getAllQuestions.test.ts
@@ -1,4 +1,5 @@
-const getAllQuestionsService = require('app/server/services/getAllQuestions.ts');
+import * as getAllQuestionsService from 'app/server/services/getAllQuestions.ts';
+const mockData = require('test/mock/cor-backend/services/all-questions').template;
 const { expect } = require('test/chai-sinon');
 const { OK, INTERNAL_SERVER_ERROR } = require('http-status-codes');
 const nock = require('nock');
@@ -7,48 +8,87 @@ const config = require('config');
 const apiUrl = config.get('api.url');
 
 describe('services/getAllQuestions.js', () => {
-  const hearingId = '121';
-  const path = `/continuous-online-hearings/${hearingId}`;
+  describe('#getAllQuestions', () => {
+    const hearingId = '121';
+    const path = `/continuous-online-hearings/${hearingId}`;
 
-  const apiResponse = {
-    deadline_extension_count: 0,
-    questions: [
-      {
-        question_id: '001',
-        question_header_text: 'How do you interact with people?',
-        answer_state: 'draft'
-      }
-    ]
-  };
+    const apiResponse = {
+      deadline_extension_count: 0,
+      questions: [
+        {
+          question_id: '001',
+          question_header_text: 'How do you interact with people?',
+          answer_state: 'draft'
+        }
+      ]
+    };
 
-  describe('resolving the promise', () => {
-    beforeEach(() => {
-      nock(apiUrl)
-        .get(path)
-        .reply(OK, apiResponse);
+    describe('resolving the promise', () => {
+      beforeEach(() => {
+        nock(apiUrl)
+          .get(path)
+          .reply(OK, apiResponse);
+      });
+
+      it('resolves the promise', () => (
+        expect(getAllQuestionsService.getAllQuestions(hearingId)).to.be.fulfilled
+      ));
+
+      it('resolves the promise with the response', () => (
+        expect(getAllQuestionsService.getAllQuestions(hearingId)).to.eventually.eql(apiResponse)
+      ));
     });
 
-    it('resolves the promise', () => (
-      expect(getAllQuestionsService(hearingId)).to.be.fulfilled
-    ));
+    describe('rejecting the promise', () => {
+      const error = { value: INTERNAL_SERVER_ERROR, reason: 'Server Error' };
 
-    it('resolves the promise with the response', () => (
-      expect(getAllQuestionsService(hearingId)).to.eventually.eql(apiResponse)
-    ));
+      beforeEach(() => {
+        nock(apiUrl)
+          .get(path)
+          .replyWithError(error);
+      });
+
+      it('rejects the promise with the error', () => (
+        expect(getAllQuestionsService.getAllQuestions(hearingId)).to.be.rejectedWith(error)
+      ));
+    });
   });
 
-  describe('rejecting the promise', () => {
-    const error = { value: INTERNAL_SERVER_ERROR, reason: 'Server Error' };
+  describe('#getQuestionIdFromOrdinal', () => {
+    const questions = mockData.questions({})
+    const questionOrdinal = '1';
+    let req: any = {};
 
     beforeEach(() => {
-      nock(apiUrl)
-        .get(path)
-        .replyWithError(error);
+      req.session = {
+        hearing: {
+          online_hearing_id: '1',
+          case_reference: 'SC/123/456',
+          appellant_name: 'John Smith'
+        },
+        questions
+      };
+      req.params = {
+        questionOrdinal
+      };
+    });
+    it('returns the question id specified by the ordinal', () => {
+      const firstQuestion = questions[0].question_id;
+      expect(getAllQuestionsService.getQuestionIdFromOrdinal(req)).to.deep.equal(firstQuestion);
+      req.params.questionOrdinal = '2';
+      const secondQuestion = questions[1].question_id;
+      expect(getAllQuestionsService.getQuestionIdFromOrdinal(req)).to.deep.equal(secondQuestion);
     });
 
-    it('rejects the promise with the error', () => (
-      expect(getAllQuestionsService(hearingId)).to.be.rejectedWith(error)
-    ));
+    it('returns undefined if no questions exist in the session', () => {
+      delete req.session.questions;
+      expect(getAllQuestionsService.getQuestionIdFromOrdinal(req)).to.be.undefined;
+    });
+
+    it('returns undefined if question ordinal param is not valid', () => {
+      delete req.params.questionOrdinal;
+      expect(getAllQuestionsService.getQuestionIdFromOrdinal(req)).to.be.undefined;
+    });
   });
 });
 


### PR DESCRIPTION
* using question ordinal instead of question id
* store questions in session after retrieving from COH
* refresh questions in session after each request for `/task-list`
* if questions are not found in the session redirect the user back to the task list page
* adjusting all link/urls for questions to use the ordinal