### PR TITLE
[PREVIEW] SSCS-4117 Fixing duplicate question URLs

### DIFF
--- a/app/server/services/getAllQuestions.ts
+++ b/app/server/services/getAllQuestions.ts
@@ -31,7 +31,8 @@ function getQuestionIdFromOrdinal(req: Request): string {
     return undefined;
   }
   const questionOrdinal: number = parseInt(req.params.questionOrdinal, 10);
-  const currentQuestion: QuestionSummary = questions.find(q => q.question_ordinal === questionOrdinal);
+  const index = questionOrdinal - 1;
+  const currentQuestion: QuestionSummary = questions[index];
   if (!currentQuestion) {
     return undefined;
   }

--- a/test/mock/cor-backend/services/all-questions.js
+++ b/test/mock/cor-backend/services/all-questions.js
@@ -42,12 +42,12 @@ module.exports = {
         answer_state: answerState('001', params.onlineHearingId)
       }, {
         question_id: '002',
-        question_ordinal: 2,
+        question_ordinal: 1,
         question_header_text: questionData['002'].header,
         answer_state: answerState('002', params.onlineHearingId)
       }, {
         question_id: '003',
-        question_ordinal: 3,
+        question_ordinal: 1,
         question_header_text: questionData['003'].header,
         answer_state: answerState('003', params.onlineHearingId)
       }

--- a/views/task-list.html
+++ b/views/task-list.html
@@ -27,7 +27,7 @@
                 {% for question in questions %}
                     {% set answerState = question.answer_state %}
                     <li id="question-{{ question.question_id }}">
-                        <a class="govuk-link question-header-text" href="/question/{{ question.question_ordinal }}">{{ question.question_header_text }}</a>
+                        <a class="govuk-link question-header-text" href="/question/{{ loop.index }}">{{ question.question_header_text }}</a>
                         {% if answerState != 'unanswered' %}
                             <span class="answer-state {{ question.answer_state }}">
                                 {{


### PR DESCRIPTION
* the issue came about because when questions are created in COH via JUI, the question ordinal is not incremented, therefore every question in the round has an ordinal of 1
* using the ordinal to drive the URLs for questions meant only the first question was accessible
* the fix is to still use the same URLs but to find the question in the list by index instead of `question_ordinal`
* the all questions mock was updated to reflect how this would be returned from the backend given the same ordinal being used for every question in COH