### PR TITLE
More fixes for question URLs using ordinals

### DIFF
--- a/app/server/controllers/question.ts
+++ b/app/server/controllers/question.ts
@@ -5,6 +5,7 @@ import { answerValidation } from '../utils/fieldValidation';
 
 function getQuestion(getAllQuestionsService, getQuestionService) {
   return async(req: Request, res: Response, next: NextFunction) => {
+    const questionOrdinal: string = req.params.questionOrdinal;
     const currentQuestionId = getAllQuestionsService.getQuestionIdFromOrdinal(req);
     if (!currentQuestionId) {
       return res.redirect(Paths.taskList);
@@ -15,7 +16,7 @@ function getQuestion(getAllQuestionsService, getQuestionService) {
 
       const question = {
         questionId: currentQuestionId,
-        questionOrdinal: response.question_ordinal,
+        questionOrdinal: questionOrdinal,
         header: response.question_header_text,
         body: response.question_body_text,
         answer_state: response.answer_state,
@@ -35,7 +36,7 @@ function getQuestion(getAllQuestionsService, getQuestionService) {
 
 function postAnswer(getAllQuestionsService, updateAnswerService) {
   return async(req: Request, res: Response, next: NextFunction) => {
-    const questionOrdinal: number = parseInt(req.params.questionOrdinal, 10);
+    const questionOrdinal: string = req.params.questionOrdinal;
     const currentQuestionId = getAllQuestionsService.getQuestionIdFromOrdinal(req);
     if (!currentQuestionId) {
       return res.redirect(Paths.taskList);

--- a/app/server/controllers/submit-question.ts
+++ b/app/server/controllers/submit-question.ts
@@ -10,7 +10,7 @@ function getSubmitQuestion(getAllQuestionsService: any) {
     if (!currentQuestionId) {
       return res.redirect(Paths.taskList);
     }
-    const questionOrdinal: number = parseInt(req.params.questionOrdinal, 10);
+    const questionOrdinal: string = req.params.questionOrdinal;
     res.render('submit-question.html', { questionOrdinal });
   };
 }

--- a/test/fixtures/coh.ts
+++ b/test/fixtures/coh.ts
@@ -78,8 +78,8 @@ async function createQuestion(hearingId, mockQuestionRef, ordinal) {
 async function createQuestions(hearingId) {
   const questionList = [];
   questionList.push(await createQuestion(hearingId, '001', 1));
-  questionList.push(await createQuestion(hearingId, '002', 2));
-  questionList.push(await createQuestion(hearingId, '003', 3));
+  questionList.push(await createQuestion(hearingId, '002', 1));
+  questionList.push(await createQuestion(hearingId, '003', 1));
   return questionList;
 }
 

--- a/test/unit/controllers/question.test.ts
+++ b/test/unit/controllers/question.test.ts
@@ -48,7 +48,7 @@ describe('controllers/question.js', () => {
       getQuestionService = null;
       getAllQuestionsService = {
         getQuestionIdFromOrdinal: sinon.stub().returns('001')
-      }
+      };
     });
 
     it('should call render with the template and question header', async() => {
@@ -73,7 +73,7 @@ describe('controllers/question.js', () => {
           questionOrdinal: '1',
           header: questionHeading,
           body: questionBody,
-          answer: { 
+          answer: {
             value: questionAnswer,
             date: questionAnswerDate,
           },

--- a/test/unit/controllers/submit-question.test.ts
+++ b/test/unit/controllers/submit-question.test.ts
@@ -52,7 +52,7 @@ describe('controllers/submit-question', () => {
 
   describe('getSubmitQuestion', () => {
     it('should call render with the template and hearing/question ids', () => {
-      const questionOrdinal = req.session.questions[0].question_ordinal;
+      const questionOrdinal = req.params.questionOrdinal;
       getSubmitQuestion(getAllQuestionsService)(req, res);
       expect(res.render).to.have.been.calledWith('submit-question.html', { questionOrdinal });
     });


### PR DESCRIPTION
* the actual ordinal was being used for the answer form post, instead using the question index as ordinal
* no need to `parseInt` anymore
* adjusting COR backend stub to give incorrect ordinals as we would get from JUI entering questions