### PR TITLE
@SSCS-4136: adding basic overnight pipeline which will test dependencies

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -1,0 +1,14 @@
+#!groovy
+
+properties([
+        pipelineTriggers([cron('00 21 * * *')])
+])
+
+@Library("Infrastructure")
+
+def product = "sscs-cor"
+def component = "frontend"
+
+withNightlyPipeline("nodejs", product, component) {
+    enableSlackNotifications('#sscs-tech')
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-4136

### Change description ###

This changes adds a simple Jenkinsfile_nightly config which will automatically run the NSP dependency checker, and results will be posted on Slack if the build fails ([or once it starts passing again](https://github.com/hmcts/cnp-jenkins-library/blob/5f476062bad590d081a9abe2755063d226f53421/README.md)).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
