### PR TITLE
SSCS-3940 Adding cloud role name to app insights

### DIFF
--- a/app/server/app-insights.ts
+++ b/app/server/app-insights.ts
@@ -3,7 +3,12 @@ const config = require('config');
 
 export const enable = () => {
   const iKey = config.get('appInsights.instrumentationKey');
-  applicationInsights.setup(iKey).setAutoCollectConsole(true, true).start();
+  applicationInsights.setup(iKey).setAutoCollectConsole(true, true);
+  applicationInsights
+    .defaultClient
+    .context
+    .tags[applicationInsights.defaultClient.context.keys.cloudRole] = config.get('appInsights.roleName');
+  applicationInsights.start();
 };
 
 export const trackException = exception => {

--- a/config/default.json
+++ b/config/default.json
@@ -7,7 +7,8 @@
     "url": "http://localhost:8090"
   },
   "appInsights": {
-    "instrumentationKey": "iKey"
+    "instrumentationKey": "iKey",
+    "roleName": "COR-FE"
   },
   "session": {
     "redis": {

--- a/test/unit/app-insights.test.ts
+++ b/test/unit/app-insights.test.ts
@@ -1,29 +1,29 @@
 const { expect, sinon } = require('test/chai-sinon');
 import * as applicationInsights from 'applicationinsights';
 import * as AppInsights from 'app/server/app-insights.ts';
+const config = require('config');
 
 describe('app-insights.js', () => {
   describe('enable', () => {
     const sb = sinon.sandbox.create();
-    let startStub = null;
 
     beforeEach(() => {
-      startStub = sb.stub();
-      sb.stub(applicationInsights, 'setup').withArgs('iKey')
-        .returns({
-          setAutoCollectConsole: sb.stub().withArgs(true, true)
-            .returns({ start: startStub })
-        });
+      sb.stub(applicationInsights, 'start');
     });
 
     afterEach(() => {
       sb.restore();
     });
 
+    it('sets cloud role name', () => {
+      AppInsights.enable();
+      expect(applicationInsights.defaultClient.context.tags['ai.cloud.role']).to.equal(config.get('appInsights.roleName'));
+    });
+
     it('should call start', () => {
       AppInsights.enable();
       // eslint-disable-next-line no-unused-expressions
-      expect(startStub).to.have.been.called;
+      expect(applicationInsights.start).to.have.been.called;
     });
   });
 });


### PR DESCRIPTION
* this is due to setting up a shared app insights for all SSCS services
* when viewing them, the logs can be filtered by cloud role name to limit them to a specific app