### PR TITLE
SSCS-4205 Limit evidence upload file size none Javascript

### DIFF
--- a/app/server/controllers/question.ts
+++ b/app/server/controllers/question.ts
@@ -13,6 +13,7 @@ const i18n = require('../../../locale/en.json');
 const upload = multer();
 const evidenceUploadEnabled = config.get('evidenceUpload.questionPage.enabled') === 'true';
 const evidenceUploadOverrideAllowed = config.get('evidenceUpload.questionPage.overrideAllowed') === 'true';
+const maxFileSizeInMb: number = config.get('evidenceUpload.maxFileSizeInMb');
 
 export function showEvidenceUpload(evidenceUploadEnabled: boolean, evidendeUploadOverrideAllowed?: boolean, cookies?): boolean {
   if (evidenceUploadEnabled) {
@@ -150,6 +151,9 @@ function postUploadEvidence(questionService: QuestionService, evidenceService: E
 
     if (!req.file) {
       const error = i18n.questionUploadEvidence.error.empty;
+      return res.render('question/upload-evidence.html', { questionOrdinal, error });
+    } else if (req.file.size > maxFileSizeInMb * 1048576) {
+      const error = `${i18n.questionUploadEvidence.error.tooLarge} ${maxFileSizeInMb}MB.`;
       return res.render('question/upload-evidence.html', { questionOrdinal, error });
     }
 

--- a/config/default.json
+++ b/config/default.json
@@ -36,6 +36,7 @@
     "questionPage": {
       "enabled": "false",
       "overrideAllowed": "false"
-    }
+    },
+    "maxFileSizeInMb": 10
   }
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -95,7 +95,8 @@
     "backToQuestionText": "Back to question",
     "uploadAFile": "Upload a file",
     "error": {
-      "empty": "You have not selected a file."
+      "empty": "You have not selected a file.",
+      "tooLarge": "The file you have uploaded is too big. Please upload a file under"
     }
   },
   "submitQuestion": {


### PR DESCRIPTION
Limit the max size of a file that can uploaded as evidence. Displays an
error if the file is too large. The max file size is set as a property
in MB.