### PR TITLE
SSCS-4349 Allow JS evidence upload errors

### DIFF
--- a/app/client/javascript/evidence-upload.ts
+++ b/app/client/javascript/evidence-upload.ts
@@ -52,8 +52,9 @@ export class EvidenceUpload {
 
   setRevealStartState(): void {
     const uploadedFiles = document.querySelectorAll('#files-uploaded tr.evidence');
+    const uploadError = document.querySelectorAll('#file-upload-1-error');
     const provideEvidence = document.getElementById(this.CHECKBOX_ID) as HTMLInputElement;
-    if (uploadedFiles.length === 0) {
+    if (uploadedFiles.length === 0 && uploadError.length === 0) {
       provideEvidence.checked = false;
       this.revealContainer.style.display = 'none';
     } else {

--- a/test/unit/client/javascript/evidence-upload.test.ts
+++ b/test/unit/client/javascript/evidence-upload.test.ts
@@ -117,7 +117,7 @@ describe('evidence-upload', () => {
     before(() => {
       revealContainer = document.getElementById(evidenceUpload.REVEAL_CONTAINER_ID);
     });
-    it('starts hidden if no uploaded files exist', () => {
+    it('starts hidden if no uploaded files exist and no upload errors', () => {
       evidenceUpload.setRevealStartState();
       const checkbox = document.getElementById(evidenceUpload.CHECKBOX_ID) as HTMLInputElement;
       expect(revealContainer.style.display).to.equal('none');
@@ -132,6 +132,14 @@ describe('evidence-upload', () => {
             <input type="submit" name="delete" value="Delete" class="govuk-link">
           </td>
         </tr>`;
+      evidenceUpload.setRevealStartState();
+      const checkbox = document.getElementById(evidenceUpload.CHECKBOX_ID) as HTMLInputElement;
+      expect(revealContainer.style.display).to.equal('block');
+      expect(checkbox.checked).to.equal(true);
+    });
+    it('starts revealed if uploaded errors exist', () => {
+      document.querySelector('#files-uploaded tbody').innerHTML =
+        `<span id="file-upload-1-error" class="govuk-error-message">some error</span>`;
       evidenceUpload.setRevealStartState();
       const checkbox = document.getElementById(evidenceUpload.CHECKBOX_ID) as HTMLInputElement;
       expect(revealContainer.style.display).to.equal('block');


### PR DESCRIPTION
With JS enabled if the first file you uploaded was too big or not of
an acceptable type the page would reload but the evidence upload
checkbox was not ticked and the error message was hidden. Make
evidence upload section visable if you have uploaded files or have
an errors.