### PR TITLE
Do not build docker images on master only PR builds

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -35,7 +35,7 @@ withPipeline("nodejs", product, component) {
     loadVaultSecrets(secrets)
     after('checkout') {sh 'yarn cache clean'}
     after('build') {sh 'yarn build'}
-    enableDockerBuild()
+    onPR { enableDockerBuild() }
     enableDeployToAKS()
     before("functionalTest:preview") {
         env.COH_URL = cohUrlAat


### PR DESCRIPTION
The PR builds use an AKS environment to run their functional tests. We do not
use this in AAT or prod and are not running the app locally with docker so do
not need to build the image.