### PR TITLE
Sscs 4412 question answer not saved

### DIFF
--- a/app/client/javascript/evidence-upload.ts
+++ b/app/client/javascript/evidence-upload.ts
@@ -30,8 +30,9 @@ export class EvidenceUpload {
     formElement.setAttribute('id', 'js-upload-form');
     formElement.setAttribute('action', formAction);
     formElement.setAttribute('method', 'post');
-    formElement.setAttribute('enctype', 'multipart/form-data');
+    formElement.appendChild(document.getElementById('question-field'));
     formElement.appendChild(document.getElementById(this.FILE_UPLOAD_ID));
+    formElement.setAttribute('enctype', 'multipart/form-data');
     document.body.appendChild(formElement);
 
     const spinner = document.getElementById('upload-spinner');

--- a/app/server/controllers/question.ts
+++ b/app/server/controllers/question.ts
@@ -236,6 +236,9 @@ function handleFileUploadErrors(isJsUpload: boolean) {
       }
       if (isJsUpload) {
         const question = req.session.question;
+        question.answer = {
+          value: req.body['question-field']
+        };
         return res.render('question/index.html', {
           question,
           showEvidenceUpload: showEvidenceUpload(evidenceUploadEnabled, evidenceUploadOverrideAllowed, req.cookies),

--- a/app/server/controllers/question.ts
+++ b/app/server/controllers/question.ts
@@ -69,7 +69,25 @@ function getQuestion(questionService: QuestionService) {
   };
 }
 
-// TODO rename function
+async function validateAnswer(req: Request, res: Response, answerText: string, callback) {
+  let validationMessage;
+  if (req.body.submit) {
+    validationMessage = answerValidation(answerText);
+  }
+  if (validationMessage) {
+    const question = req.session.question;
+    question.answer = {
+      value: answerText,
+      error: validationMessage
+    };
+    return res.render('question/index.html', {
+      question,
+      showEvidenceUpload: showEvidenceUpload(evidenceUploadEnabled, evidenceUploadOverrideAllowed, req.cookies)
+    });
+  }
+  await callback();
+}
+
 function postAnswer(questionService: QuestionService, evidenceService: EvidenceService) {
   return async(req: Request, res: Response, next: NextFunction) => {
     const questionOrdinal: string = req.params.questionOrdinal;
@@ -80,80 +98,29 @@ function postAnswer(questionService: QuestionService, evidenceService: EvidenceS
     const hearingId = req.session.hearing.online_hearing_id;
     const answerText = req.body['question-field'];
 
-    if (req.file) {
-      if (answerText.length > 0) {
-        try {
-          await questionService.saveAnswer(hearingId, currentQuestionId, 'draft', answerText);
-        } catch (error) {
-          AppInsights.trackException(error);
-          return next(error);
-        }
-      }
-      return postUploadEvidence(questionService, evidenceService, true)(req, res, next);
-    }
-
-    // TODO refactor after merge
-    if (req.body['add-file']) {
-      if (answerText.length > 0) {
-        try {
-          await questionService.saveAnswer(hearingId, currentQuestionId, 'draft', answerText);
-        } catch (error) {
-          AppInsights.trackException(error);
-          return next(error);
-        }
-      }
-      return res.redirect(`${Paths.question}/${questionOrdinal}/upload-evidence`);
-    }
-
-    // TODO refactor after merge
-    if (req.body.delete) {
-      if (answerText.length > 0) {
-        try {
-          await questionService.saveAnswer(hearingId, currentQuestionId, 'draft', answerText);
-        } catch (error) {
-          AppInsights.trackException(error);
-          return next(error);
-        }
-      }
-      try {
-        const fileId = Object.keys(req.body.delete)[0];
-        await evidenceService.remove(hearingId, currentQuestionId, fileId);
-        return res.redirect(`${Paths.question}/${questionOrdinal}`);
-      } catch (error) {
-        AppInsights.trackException(error);
-        return next(error);
-      }
-    }
-
-    let validationMessage;
-    if (req.body.submit) {
-      validationMessage = answerValidation(answerText);
-    }
-
-    if (validationMessage) {
-      const question = req.session.question;
-      question.answer = {
-        value: answerText,
-        error: validationMessage
-      };
-      res.render('question/index.html', {
-        question,
-        showEvidenceUpload: showEvidenceUpload(evidenceUploadEnabled, evidenceUploadOverrideAllowed, req.cookies)
-      });
-    } else {
-      try {
+    try {
+      await validateAnswer(req, res, answerText, async () => {
         if (answerText.length > 0) {
           await questionService.saveAnswer(hearingId, currentQuestionId, 'draft', answerText);
         }
-        if (req.body.submit) {
+
+        if (req.file) {
+          return postUploadEvidence(questionService, evidenceService, true)(req, res, next);
+        } else if (req.body['add-file']) {
+          return res.redirect(`${Paths.question}/${questionOrdinal}/upload-evidence`);
+        } else if (req.body.delete) {
+          const fileId = Object.keys(req.body.delete)[0];
+          await evidenceService.remove(hearingId, currentQuestionId, fileId);
+          return res.redirect(`${Paths.question}/${questionOrdinal}`);
+        } else if (req.body.submit) {
           res.redirect(`${Paths.question}/${questionOrdinal}/submit`);
         } else {
           res.redirect(Paths.taskList);
         }
-      } catch (error) {
-        AppInsights.trackException(error);
-        next(error);
-      }
+      });
+    } catch (error) {
+      AppInsights.trackException(error);
+      return next(error);
     }
   };
 }
@@ -187,7 +154,6 @@ function postUploadEvidence(questionService: QuestionService, evidenceService: E
       const error = i18n.questionUploadEvidence.error.empty;
       return res.render('question/upload-evidence.html', { questionOrdinal, error });
     }
-
     try {
       const response: rp.Response = await evidenceService.upload(hearingId, currentQuestionId, req.file);
       if (response.statusCode === OK) {

--- a/app/server/controllers/question.ts
+++ b/app/server/controllers/question.ts
@@ -183,7 +183,7 @@ function postUploadEvidence(questionService: QuestionService, evidenceService: E
 
 function fileTypeInWhitelist(req, file, cb) {
   const fileExtension = path.extname(file.originalname);
-  if (mimeTypeWhitelist.mimeTypes.includes(file.mimetype) && mimeTypeWhitelist.fileTypes.includes(fileExtension)) {
+  if (mimeTypeWhitelist.mimeTypes.includes(file.mimetype) && mimeTypeWhitelist.fileTypes.includes(fileExtension.toLocaleLowerCase())) {
     cb(null, true);
   } else {
     cb(new multer.MulterError(fileTypeError));

--- a/test/browser/3-question.test.ts
+++ b/test/browser/3-question.test.ts
@@ -238,6 +238,31 @@ describe('Question page', () => {
         const finalCount: number = await questionPage.countEvidence();
         expect(finalCount).to.equal(0);
       });
+
+      it('remembers changes to answer when uploading evidence', async () => {
+        await questionPage.visitPage();
+        const newAnswer = 'a new upload answer no js';
+        await questionPage.answerNoSubmit(newAnswer);
+        await Promise.all([
+          page.waitForNavigation(),
+          questionPage.clickElement('#add-file')
+        ]);
+        await uploadEvidencePage.selectFile('evidence.pdf');
+        await uploadEvidencePage.submit();
+        questionPage.verifyPage();
+        const savedAnswer = await questionPage.getElementValue('#question-field');
+        expect(savedAnswer).to.equal(newAnswer);
+      });
+
+      it('remembers changes to answer when deleting evidence', async () => {
+        await questionPage.visitPage();
+        const newAnswer = 'a new delete answer no js';
+        await questionPage.answerNoSubmit(newAnswer);
+        await questionPage.deleteEvidence();
+        questionPage.verifyPage();
+        const savedAnswer = await questionPage.getElementValue('#question-field');
+        expect(savedAnswer).to.equal(newAnswer);
+      });
     });
 
     describe('with javascript ON', () => {
@@ -317,6 +342,39 @@ describe('Question page', () => {
         }
         const finalCount: number = await questionPage.countEvidence();
         expect(finalCount).to.equal(0);
+      });
+
+      it('remembers changes to answer when uploading evidence', async () => {
+        const newAnswer = 'a new upload answer';
+        await questionPage.answerNoSubmit(newAnswer);
+        await Promise.all([
+          page.waitForNavigation(),
+          questionPage.selectFile('evidence.pdf')
+        ]);
+        questionPage.verifyPage();
+        const savedAnswer = await questionPage.getElementValue('#question-field');
+        expect(savedAnswer).to.equal(newAnswer);
+      });
+
+      it('remembers changes to answer when deleting evidence', async () => {
+        const newAnswer = 'a new delete answer';
+        await questionPage.answerNoSubmit(newAnswer);
+        await questionPage.deleteEvidence();
+        questionPage.verifyPage();
+        const savedAnswer = await questionPage.getElementValue('#question-field');
+        expect(savedAnswer).to.equal(newAnswer);
+      });
+
+      it('remembers changes to answer when evidence not allowed', async () => {
+        const newAnswer = 'a new not allowed answer';
+        await questionPage.answerNoSubmit(newAnswer);
+        await Promise.all([
+          page.waitForNavigation(),
+          questionPage.selectFile('disallowed_evidence.disallowed')
+        ]);
+        questionPage.verifyPage();
+        const savedAnswer = await questionPage.getElementValue('#question-field');
+        expect(savedAnswer).to.equal(newAnswer);
       });
     });
   });

--- a/test/page-objects/question.ts
+++ b/test/page-objects/question.ts
@@ -43,7 +43,7 @@ export class QuestionPage extends BasePage {
   async deleteEvidence() {
     await Promise.all([
       this.page.waitForNavigation(),
-      this.clickElement('input[name="delete"]')
+      this.clickElement('input[name^="delete"]')
     ]);
   }
 

--- a/test/page-objects/question.ts
+++ b/test/page-objects/question.ts
@@ -8,8 +8,12 @@ export class QuestionPage extends BasePage {
     this.pagePath = `${question}/${questionOrdinal}`;
   }
 
-  async answer(answer, submit) {
+  async answerNoSubmit(answer) {
     await this.enterTextintoField('#question-field', answer);
+  }
+
+  async answer(answer, submit) {
+    await this.answerNoSubmit(answer);
     const buttonId = submit ? '#submit-answer' : '#save-answer';
     await Promise.all([
       this.page.waitForNavigation(),

--- a/test/unit/client/javascript/evidence-upload.test.ts
+++ b/test/unit/client/javascript/evidence-upload.test.ts
@@ -1,7 +1,9 @@
 import { expect, sinon } from 'test/chai-sinon';
 import { EvidenceUpload } from 'app/client/javascript/evidence-upload';
 
-const html = `<form id="answer-form" action="/question/1" method="post"></form>
+const html = `<form id="answer-form" action="/question/1" method="post">
+    <input type="text" id="question-field" name="question-field"/>
+</form>
 <div id="evidence-upload">
 <div class="govuk-form-group">
   <div class="govuk-checkboxes evidence-upload-js" style="display: block;">

--- a/test/unit/controllers/question.test.ts
+++ b/test/unit/controllers/question.test.ts
@@ -171,9 +171,12 @@ describe('controllers/question', () => {
     });
 
     it('should delete a file', async() => {
-      req.body.delete = 'Delete';
+      req.body.delete = { 'fileId1': 'Delete' };
       req.body.id = 'uuid';
+      req.body['question-field'] = 'some question answer';
       await postAnswer(questionService, evidenceService)(req, res, next);
+      expect(questionService.saveAnswer).to.have.been.calledOnce.calledWith('1', questionId, 'draft', req.body['question-field']);
+      expect(evidenceService.remove).to.have.been.calledWith('1', questionId, 'fileId1');
       expect(res.redirect).to.have.been.calledOnce.calledWith(`${Paths.question}/${questionOrdinal}`);
     });
 
@@ -203,7 +206,9 @@ describe('controllers/question', () => {
         req.file = { name: 'myfile.txt' };
       });
       it('calls postUploadEvidence to upload the file', async () => {
+        req.body['question-field'] = 'some question answer';
         await postAnswer(questionService, evidenceService)(req, res, next);
+        expect(questionService.saveAnswer).to.have.been.calledOnce.calledWith('1', questionId, 'draft', req.body['question-field']);
         expect(evidenceService.upload).to.have.been.calledOnce;
       });
     });

--- a/views/question/evidence-list.html
+++ b/views/question/evidence-list.html
@@ -9,10 +9,7 @@
       <tr class="govuk-table__row evidence">
         <td class="govuk-table__cell">{{ file.filename }}</td>
         <td class="govuk-table__cell">
-          <form action="/question/{{ question.questionOrdinal }}" method="post">
-            <input type="hidden" name="id" value="{{ file.id }}">
-            <input type="submit" name="delete" value="{{ i18n.general.delete }}" class="govuk-link">
-          </form>
+            <input type="submit" name="delete[{{ file.id }}]" value="{{ i18n.general.delete }}" class="govuk-link">
         </td>
       </tr>
     {% else %}


### PR DESCRIPTION
On the answer a question page if the user updated their answer and then either uploaded or deleted evidence the update to the answer was not being saved.

These cases have been fixed
- Upload evidence JS on.
- Upload evidence and there was an error (file too large or wrong type) JS on.
- Delete evidence JS on or off.