### PR TITLE
Remove git dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:8.12.0-slim
 
-RUN apt-get update && apt-get install -y git
-
 # Create app directory
 WORKDIR /usr/src/app
 

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "nock": "^9.4.4",
     "nodemon": "^1.18.3",
     "nyc": "^13.0.1",
-    "pa11y": "git+https://github.com/jozzhart/pa11y.git",
+    "pa11y": "https://github.com/chrisgrimble/pa11y/tarball/v5.1.0-HMCTS-BUG-FIX",
     "pre-commit": "^1.2.2",
     "puppeteer": "^1.10.0",
     "sinon": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5037,9 +5037,9 @@ pa11y-reporter-json@^1.0.0:
   dependencies:
     bfj "^4.2.3"
 
-"pa11y@git+https://github.com/jozzhart/pa11y.git":
+"pa11y@https://github.com/chrisgrimble/pa11y/tarball/v5.1.0-HMCTS-BUG-FIX":
   version "5.1.0"
-  resolved "git+https://github.com/jozzhart/pa11y.git#30ed35268b18d7b77fa1de034c6e419de407ac43"
+  resolved "https://github.com/chrisgrimble/pa11y/tarball/v5.1.0-HMCTS-BUG-FIX#08673eb288028eb283fc864f563ec5868d99a3b3"
   dependencies:
     commander "^2.19.0"
     fs-extra "^5.0.0"


### PR DESCRIPTION
We are relying on a bug fix to Pa11y that has not been merged into their
project yet. This is hosted on a fork of Pa11y. Previously the
dependency in package.json was of the form git+http://github.com...
This did not work when we tried to build our app on the docker image
provided to CNP as it did not have git installed. We were doing an
apt-get update && apt-get install git every time. Changed the dependency
to use the tarball from github created by a tag which does not need git.