### PR TITLE
SSCS-4424 Changed links to secondary buttons

### DIFF
--- a/app/server/controllers/login.ts
+++ b/app/server/controllers/login.ts
@@ -67,10 +67,8 @@ function getIdamCallback(
     try {
       logger.info('getting token');
       const tokenResponse: TokenResponse = await idamService.getToken(code, req.protocol, req.hostname);
-      logger.info('tokenResponse', tokenResponse);
       logger.info('getting user details');
       const userDetails: UserDetails = await idamService.getUserDetails(tokenResponse.access_token);
-      logger.info('userDetails', userDetails);
       // todo Maybe need to check userDetails.accountStatus is 'active' and userDetails.roles contains 'citizen' on userDetails
 
       req.session.accessToken = tokenResponse.access_token;

--- a/views/question/answer-form.html
+++ b/views/question/answer-form.html
@@ -101,6 +101,6 @@
 
   <div id="submit-buttons">
     <input id="submit-answer" type="submit" name="submit" value="Submit answer to the tribunal" class="govuk-button">
-    <input id="save-answer" type="submit" name="save" value="Save for later" class="govuk-link">
+    <input id="save-answer" type="submit" name="save" value="Save for later" class="govuk-button secondary-button">
   </div>
 </form>

--- a/views/submit-question.html
+++ b/views/submit-question.html
@@ -9,9 +9,9 @@
             <form action="/question/{{ questionOrdinal }}/submit" method="post">
                 <div id="submit-buttons">
                     <input id="submit-answer" type="submit" name="submit" value="Confirm" class="govuk-button">
+                    <a class="govuk-button secondary-button" href="/question/{{ questionOrdinal }}">{{ i18n.submitQuestion.backToQuestionText }}</a>
                 </div>
             </form>
-            <a class="govuk-link" href="/question/{{ questionOrdinal }}">{{ i18n.submitQuestion.backToQuestionText }}</a>
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
User research has shown that the links to save you answer on the answer
page or go back to question on the submit confirmation page are not
being seen by users. Changed them to secondary buttons to make them
more visible. Also removed some logs in login as I think they will be
writing user details to the logs.