### PR TITLE
Add a way to get the S2S headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,15 @@ And use the command:
 HTTP_PROXY=http://proxyout.reform.hmcts.net:8080 SSCS_API_URL=http://sscs-cor-backend-aat.service.core-compute-aat.internal COH_URL=http://coh-cor-aat.service.core-compute-aat.internal IDAM_API_URL=https://idam-api.aat.platform.hmcts.net S2S_URL=http://rpe-service-auth-provider-aat.service.core-compute-aat.internal S2S_SECRET=XXXXXXXXXXXXX yarn test:create-data
 ```
 
+If you then want to make calls directly to COH to change the state of an online hearing you will need the S2S headers 
+these can be generated with
+
+```bash
+yarn test:create-s2s-headers
+```
+
+You will need the same environment variables used when creating test data. 
+
 ### Analytics
 
 Analytics are tracking using Google Tag Manager (GTM) and Google Analytics (GA), all managed under the SSCS account.

--- a/create-s2s-header.ts
+++ b/create-s2s-header.ts
@@ -1,0 +1,18 @@
+import { bootstrapCreateS2sTokens } from './test/browser/bootstrap';
+import * as clc from 'cli-color';
+
+const bold = clc.bold;
+const blue = clc.blueBright.bold;
+const white = clc.whiteBright;
+
+/* tslint:disable no-console */
+async function runBootstrap() {
+  const { Authorization, ServiceAuthorization } = await bootstrapCreateS2sTokens();
+
+  console.log('\n' + blue(bold('Authorization: ')) + white(Authorization));
+  console.log('\n' + blue(bold('ServiceAuthorization: ')) + white(ServiceAuthorization));
+}
+
+runBootstrap()
+  .then(() => console.log('Complete'))
+  .catch(e => console.error('Failed', e));

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:integration": "cross-env NODE_PATH=. TS_NODE_PROJECT=app/server/tsconfig.json NODE_ENV=test mocha test/integration/**/*.ts",
     "test:functional": "yarn test:browser -g '@smoke|@pa11y' --invert",
     "test:smoke": "yarn test:browser -g @smoke",
+    "test:create-s2s-headers": "cross-env NODE_PATH=. TS_NODE_PROJECT=app/server/tsconfig.json node --require tsconfig-paths/register --require ts-node/register create-s2s-header.ts",
     "test:create-data": "cross-env NODE_PATH=. TS_NODE_PROJECT=app/server/tsconfig.json node --require tsconfig-paths/register --require ts-node/register create-test-data.ts",
     "test:create-data-aat": "cross-env HTTP_PROXY=http://proxyout.reform.hmcts.net:8080 SSCS_API_URL=http://sscs-cor-backend-aat.service.core-compute-aat.internal COH_URL=http://coh-cor-aat.service.core-compute-aat.internal IDAM_API_URL=https://idam-api.aat.platform.hmcts.net S2S_URL=http://rpe-service-auth-provider-aat.service.core-compute-aat.internal yarn test:create-data",
     "test:coverage": "yarn transpile && nyc yarn test:unit",

--- a/test/browser/bootstrap.ts
+++ b/test/browser/bootstrap.ts
@@ -102,3 +102,8 @@ export async function createAndIssueDecision(hearingId) {
     return Promise.reject(error);
   }
 }
+
+export async function bootstrapCreateS2sTokens() {
+  const headers = await coh.getHeaders();
+  return headers;
+}

--- a/test/fixtures/coh.ts
+++ b/test/fixtures/coh.ts
@@ -157,5 +157,6 @@ export {
   getQuestionRound,
   getDecision,
   createDecision,
-  issueDecision
+  issueDecision,
+  getHeaders
 };


### PR DESCRIPTION
If you need a pair of S2S headers then you can call
yarn test:create-s2s-headers
to create them. Full instructions in README.md