### PR TITLE
[SCSS-4590] removing hide from answer labels for Accessibility.

### DIFF
--- a/views/question/answer-form.html
+++ b/views/question/answer-form.html
@@ -9,8 +9,7 @@
         name: 'question-field',
         value: question.answer.value,
         label: {
-            text: i18n.question.textareaField.label,
-            classes: 'govuk-visually-hidden'
+            text: i18n.question.textareaField.label
         },
         attributes: {
             placeholder: i18n.question.textareaField.placeholder


### PR DESCRIPTION
To avoid Accessibility problem for screen readers removed the hidden class from question labels.


<img width="779" alt="scss-4590" src="https://user-images.githubusercontent.com/1122596/49998243-b232a280-ff8b-11e8-8716-cd9f3b0fabf2.png">
