### PR TITLE
SSCS-5230 Show final decision

### DIFF
--- a/app/server/controllers/decision.ts
+++ b/app/server/controllers/decision.ts
@@ -1,12 +1,10 @@
 import { Router, Request, Response } from 'express';
 import * as Paths from '../paths';
 import { OnlineHearing } from '../services/hearing';
-import { CONST } from '../../constants';
 
 function getDecision(req: Request, res: Response) {
   const hearing: OnlineHearing = req.session.hearing;
-  const decisionStates = [CONST.DECISION_ACCEPTED_STATE, CONST.DECISION_REJECTED_STATE];
-  if (hearing.decision && decisionStates.includes(hearing.decision.decision_state)) {
+  if (hearing.has_final_decision) {
     return res.render('decision.html', { decision: hearing.decision, final_decision: hearing.final_decision.reason });
   }
   return res.redirect(Paths.logout);

--- a/app/server/middleware/check-decision.ts
+++ b/app/server/middleware/check-decision.ts
@@ -16,6 +16,9 @@ export function checkDecision(req: Request, res: Response, next: NextFunction) {
   logger.info(`Disallowing request for ${req.path} due to decision state ${decisionState}`);
   if (decisionState === CONST.TRIBUNAL_VIEW_ISSUED_STATE) {
     const appellantReply = hearing.decision.appellant_reply;
+    if (hearing.has_final_decision) {
+      return res.redirect(Paths.decision);
+    }
     if (appellantReply === 'decision_accepted') {
       return res.redirect(Paths.tribunalViewAccepted);
     }

--- a/app/server/services/hearing.ts
+++ b/app/server/services/hearing.ts
@@ -18,6 +18,7 @@ export interface OnlineHearing {
   case_reference: string;
   online_hearing_id: string;
   decision?: OnlineHearingDecision;
+  has_final_decision: boolean;
   final_decision?: FinalDecision;
 }
 

--- a/test/mock/cor-backend/services/hearing.js
+++ b/test/mock/cor-backend/services/hearing.js
@@ -29,6 +29,15 @@ const createFinalDecision = email => {
   return {};
 };
 
+const hasFinalDecision = email => {
+  const finalDecisionEmails = [
+    'appeal.upheld@example.com',
+    'appeal.denied@example.com'
+  ];
+
+  return finalDecisionEmails.includes(email);
+};
+
 const createDecision = email => {
   const decisionIssued = cache.get('decisionIssued');
   const tribunalViewReply = cache.get('tribunalViewReply');
@@ -106,6 +115,7 @@ module.exports = {
     case_reference: 'SC/112/233',
     online_hearing_id: (params, query) => emailHearingIdMap[query.email] || '1-pending',
     decision: (params, query) => createDecision(query.email),
-    final_decision: (params, query) => createFinalDecision(query.email)
+    final_decision: (params, query) => createFinalDecision(query.email),
+    has_final_decision: (params, query) => hasFinalDecision(query.email)
   }
 };

--- a/test/unit/controllers/decision.test.ts
+++ b/test/unit/controllers/decision.test.ts
@@ -23,7 +23,8 @@ describe('controllers/decision.js', () => {
       },
       final_decision: {
         reason: 'final decision reason'
-      }
+      },
+      has_final_decision: true
     };
     req = {
       session: {
@@ -37,7 +38,7 @@ describe('controllers/decision.js', () => {
   });
 
   describe('getDecision', () => {
-    it('renders decision page with accepted decision', async() => {
+    it('renders decision page when have final decision', async() => {
       await getDecision(req, res);
       expect(res.render).to.have.been.calledOnce.calledWith('decision.html', {
         decision: hearingDetails.decision,
@@ -45,23 +46,8 @@ describe('controllers/decision.js', () => {
       });
     });
 
-    it('renders decision page with rejected decision', async() => {
-      req.session.hearing.decision.decision_state = 'decision_rejected';
-      await getDecision(req, res);
-      expect(res.render).to.have.been.calledOnce.calledWith('decision.html', {
-        decision: hearingDetails.decision,
-        final_decision: hearingDetails.final_decision.reason
-      });
-    });
-
-    it('redirects to /sign-out if decision is not issued', async() => {
-      req.session.hearing.decision.decision_state = 'decision_drafted';
-      await getDecision(req, res);
-      expect(res.redirect).to.have.been.calledWith(Paths.logout);
-    });
-
-    it('redirects to /sign-out if decision is not present', async() => {
-      delete req.session.hearing.decision;
+    it('redirects to /sign-out if final decision is not issued', async() => {
+      req.session.hearing.has_final_decision = false;
       await getDecision(req, res);
       expect(res.redirect).to.have.been.calledWith(Paths.logout);
     });

--- a/test/unit/controllers/hearing-confirm.test.ts
+++ b/test/unit/controllers/hearing-confirm.test.ts
@@ -22,7 +22,8 @@ describe('controllers/hearing-confirm', () => {
         end_date: '2020-10-10',
         decision_state: 'decision_issued',
         decision_state_datetime: moment.utc().format()
-      }
+      },
+      has_final_decision: false
     };
     req = {
       session: {

--- a/test/unit/controllers/hearing-why.test.ts
+++ b/test/unit/controllers/hearing-why.test.ts
@@ -26,7 +26,8 @@ describe('controllers/hearing-why', () => {
         end_date: '2019-09-01',
         decision_state: 'decision_issued',
         decision_state_datetime: now
-      }
+      },
+      has_final_decision: false
     };
     req = {
       session: {

--- a/test/unit/controllers/tribunal-view-confirm.test.ts
+++ b/test/unit/controllers/tribunal-view-confirm.test.ts
@@ -25,8 +25,8 @@ describe('controllers/tribunal-view-confirm', () => {
         end_date: '2019-09-01',
         decision_state: 'decision_issued',
         decision_state_datetime: moment.utc().format()
-
-      }
+      },
+      has_final_decision: false
     };
     req = {
       session: {

--- a/test/unit/controllers/tribunal-view.test.ts
+++ b/test/unit/controllers/tribunal-view.test.ts
@@ -26,7 +26,8 @@ describe('controllers/tribunal-view', () => {
         end_date: '2019-09-01',
         decision_state: 'decision_issued',
         decision_state_datetime: moment.utc().format()
-      }
+      },
+      has_final_decision: false
     };
     req = {
       session: {

--- a/test/unit/middleware/check-decision.test.ts
+++ b/test/unit/middleware/check-decision.test.ts
@@ -61,6 +61,11 @@ describe('middleware/check-decision', () => {
       checkDecision(req, res, next);
       expect(res.redirect).to.have.been.calledOnce.calledWith(Paths.hearingWhy);
     });
+    it('redirects to decision page if a final decision has been issued', () => {
+      req.session.hearing.has_final_decision = true;
+      checkDecision(req, res, next);
+      expect(res.redirect).to.have.been.calledOnce.calledWith(Paths.decision);
+    });
   });
 
   it('redirects to decision page if decision is accepted', () => {

--- a/test/unit/routes.test.ts
+++ b/test/unit/routes.test.ts
@@ -137,7 +137,8 @@ describe('Routes', () => {
               decision_state: CONST.DECISION_ACCEPTED_STATE
             },
             decision_state: '',
-            final_decision: { reason: 'final decision reason' }
+            final_decision: { reason: 'final decision reason' },
+            has_final_decision: true
           };
           next();
         });


### PR DESCRIPTION
When the final decision page was originally written we expected the COH
state to reflect the final decision. This has not been done so we have
added has_final_decision to the api call on the backend when loading a
hearing. This looks in the the appeals history to see if a final
decision has been issued. Use this to decide if we show the final
decision page.