### PR TITLE
SSCS-5218 Tables in tribunal view when empty

### DIFF
--- a/views/tribunal-view.html
+++ b/views/tribunal-view.html
@@ -74,7 +74,7 @@
             </span>
           </summary>
           <div class="govuk-details__text">
-            {% if decision.activities.daily_living %}
+
             <h2 class="govuk-heading-m">{{ i18n.tribunalView.dailyLivingActivitiesHeader }}</h2>
             <table class="govuk-table">
               <thead class="govuk-table__head">
@@ -85,20 +85,24 @@
               </tr>
               </thead>
               <tbody class="govuk-table__body">
-              {% for activity in decision.activities.daily_living %}
-                <tr class="govuk-table__row">
-                  <td class="govuk-table__cell align--top">{{ i18n.tribunalView.activities.dailyLiving[activity.activity].name }}</td>
-                  <td class="govuk-table__cell align--top">{{ i18n.tribunalView.activities.dailyLiving[activity.activity].scores[activity.selection_key].text | safe }}</td>
-                  <td class="govuk-table__cell align--top">{{ i18n.tribunalView.activities.dailyLiving[activity.activity].scores[activity.selection_key].score }}</td>
-                </tr>
-              {% endfor %}
+              {% if decision.activities.daily_living %}
+                {% for activity in decision.activities.daily_living %}
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell align--top">{{ i18n.tribunalView.activities.dailyLiving[activity.activity].name }}</td>
+                    <td class="govuk-table__cell align--top">{{ i18n.tribunalView.activities.dailyLiving[activity.activity].scores[activity.selection_key].text | safe }}</td>
+                    <td class="govuk-table__cell align--top">{{ i18n.tribunalView.activities.dailyLiving[activity.activity].scores[activity.selection_key].score }}</td>
+                  </tr>
+                {% endfor %}
               {% else %}
-                <h2 class="govuk-heading-m">{{ i18n.tribunalView.dailyLivingActivitiesHeaderEmpty }}</h2>
+              <tr class="govuk-table__row">
+                <td class="govuk-table__cell align--top" colspan="3">
+                  {{ i18n.tribunalView.dailyLivingActivitiesHeaderEmpty }}
+                </td>
+              </tr>
               {% endif %}
               </tbody>
             </table>
             <br />
-            {% if decision.activities.mobility %}
             <h2 class="govuk-heading-m">{{ i18n.tribunalView.mobilityActivitiesHeader }}</h2>
             <table class="govuk-table">
               <thead class="govuk-table__head">
@@ -109,15 +113,20 @@
               </tr>
               </thead>
               <tbody class="govuk-table__body">
-              {% for activity in decision.activities.mobility %}
-              <tr class="govuk-table__row">
-                <td class="govuk-table__cell align--top">{{ i18n.tribunalView.activities.mobility[activity.activity].name }}</td>
-                <td class="govuk-table__cell align--top">{{ i18n.tribunalView.activities.mobility[activity.activity].scores[activity.selection_key].text | safe }}</td>
-                <td class="govuk-table__cell align--top">{{ i18n.tribunalView.activities.mobility[activity.activity].scores[activity.selection_key].score }}</td>
-              </tr>
-              {% endfor %}
+              {% if decision.activities.mobility %}
+                {% for activity in decision.activities.mobility %}
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell align--top">{{ i18n.tribunalView.activities.mobility[activity.activity].name }}</td>
+                  <td class="govuk-table__cell align--top">{{ i18n.tribunalView.activities.mobility[activity.activity].scores[activity.selection_key].text | safe }}</td>
+                  <td class="govuk-table__cell align--top">{{ i18n.tribunalView.activities.mobility[activity.activity].scores[activity.selection_key].score }}</td>
+                </tr>
+                {% endfor %}
               {% else %}
-                <h2 class="govuk-heading-m">{{ i18n.tribunalView.mobilityActivitiesHeaderEmpty }}</h2>
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell align--top" colspan="3">
+                    {{ i18n.tribunalView.mobilityActivitiesHeaderEmpty }}
+                  </td>
+                </tr>
               {% endif %}
               </tbody>
             </table>


### PR DESCRIPTION
Updated the tables on the tribunal view when there is no daily living or
mobility activities.