### PR TITLE
SSCS-5230 View final decision when there is no Preliminary View

### DIFF
--- a/app/server/middleware/check-decision.ts
+++ b/app/server/middleware/check-decision.ts
@@ -10,7 +10,7 @@ const acceptedDecisionStates = [CONST.TRIBUNAL_VIEW_ISSUED_STATE, CONST.DECISION
 export function checkDecision(req: Request, res: Response, next: NextFunction) {
   const hearing: OnlineHearing = req.session.hearing;
   const decisionState = hearing.decision && hearing.decision.decision_state;
-  if (!acceptedDecisionStates.includes(decisionState)) {
+  if (!acceptedDecisionStates.includes(decisionState) && !hearing.has_final_decision) {
     return next();
   }
   logger.info(`Disallowing request for ${req.path} due to decision state ${decisionState}`);

--- a/test/unit/middleware/check-decision.test.ts
+++ b/test/unit/middleware/check-decision.test.ts
@@ -22,7 +22,8 @@ describe('middleware/check-decision', () => {
             decision_reason: 'The decision',
             decision_text: 'The decision',
             decision_state: 'decision_drafted'
-          }
+          },
+          has_final_decision: false
         }
       }
     } as any;
@@ -66,6 +67,13 @@ describe('middleware/check-decision', () => {
       checkDecision(req, res, next);
       expect(res.redirect).to.have.been.calledOnce.calledWith(Paths.decision);
     });
+  });
+
+  it('redirects to decision page if final decision has been issued and no prelimary view', () => {
+    req.session.hearing.has_final_decision = true;
+    req.session.hearing.decision = { 'reason': 'FINAL decision notes' };
+    checkDecision(req, res, next);
+    expect(res.redirect).to.have.been.calledOnce.calledWith(Paths.decision);
   });
 
   it('redirects to decision page if decision is accepted', () => {


### PR DESCRIPTION
In JUI the panel can issue a final decision without issuing a
preliminary view. COR could not handle this as it tries to parse
it as a Preliminary view and some of the data is not there. Update
routing to use the has_final_decision attribute of the hearing to
display the final decision screen.