### PR TITLE
SSCS-5221 Missing budget description in PV

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -451,7 +451,7 @@
               "text": "Cannot make any budgeting decisions at all",
               "score": 6
             },
-            "2.0": {
+            "2": {
               "text": "Needs prompting or assistance to be able to make complex budgeting decisions",
               "score": 2
             }


### PR DESCRIPTION
The mapping was out of date when the panel had select 2 points for
budgeting activity.