### PR TITLE
SSCS-3973 Decision title missing

### DIFF
--- a/test/integration/login.test.ts
+++ b/test/integration/login.test.ts
@@ -113,16 +113,6 @@ describe('Login page', () => {
     expect(await decisionPage.getElementText('#decision-text')).to.equal('final decision reason');
   });
 
-  it('displays the decision page with appeal denied', async() => {
-    await loginPage.visitPage();
-    await loginPage.login('appeal.denied@example.com', 'examplePassword');
-    await loginPage.screenshot('decision-denied-upheld-login');
-    decisionPage.verifyPage();
-    expect(await decisionPage.getHeading()).to.equal(i18n.tribunalDecision.header);
-    expect(await decisionPage.getElementText('#decision-outcome h2')).to.equal(i18n.tribunalDecision.outcome.decision_rejected);
-    expect(await decisionPage.getElementText('#decision-text')).to.equal('final decision reason');
-  });
-
   it('does not allow access to task list when decision is issued', async() => {
     await taskListPage.visitPage();
     await loginPage.screenshot('decision-issued-task-list-navigate');

--- a/views/decision.html
+++ b/views/decision.html
@@ -16,7 +16,7 @@
         <div class="govuk-grid-column-two-thirds">
             <div id="decision">
                 <div id="decision-outcome" class="panel-blue">
-                    <h2 class="govuk-heading-m">{{ i18n.tribunalDecision.outcome[decision.decision_state] }}</h2>
+                    <h2 class="govuk-heading-m">{{ i18n.tribunalDecision.outcome.decision_accepted }}</h2>
                 </div>
                 <div id="decision-reason">
                     <h2 class="govuk-heading-m">{{ i18n.tribunalDecision.reasonsHeader }}</h2>


### PR DESCRIPTION
When we wrote this there was an idea that the appellant would see an
accepted or rejected decision. But if the panel rejects the appeal they
will relist it rather than show the appeal rejected here. Changed the
title of the decision page to be static as it no longer needs to
select between accepted and rejected and the states are not set anyway.