### PR TITLE
Providing additional evidence link and additional evidence landing page

### DIFF
--- a/app/server/controllers/additional-evidence.ts
+++ b/app/server/controllers/additional-evidence.ts
@@ -2,16 +2,25 @@ import { Router, Request, Response } from 'express';
 
 import * as Paths from '../paths';
 
+const allowedActions = [
+  'upload',
+  'statement',
+  'post'
+];
+
 function getadditionalEvidence (req: Request, res: Response) {
-  // TODO Logic should be added for now this is just an example.
-  let additionalEvidence = { state: 'evidencePost' };
-  return res.render('additional-evidence/index.html', { additionalEvidence });
+  const action: string =
+    (!allowedActions.includes(req.params.action) || !req.params.action) ?
+      'options'
+      :
+      req.params.action;
+
+  return res.render('additional-evidence/index.html', { action });
 }
 
 function setupadditionalEvidenceController(deps: any) {
-  // eslint-disable-next-line new-cap
   const router = Router();
-  router.get(Paths.additionalEvidence, deps.prereqMiddleware, getadditionalEvidence);
+  router.get(`${Paths.additionalEvidence}/:action?`, deps.prereqMiddleware, getadditionalEvidence);
   return router;
 }
 

--- a/locale/en.json
+++ b/locale/en.json
@@ -64,12 +64,6 @@
       }
     }
   },
-  "additionalEvidence": {
-    "backToAppeal": "Back to Your benefit appeal",
-    "evidenceOptions": {
-      "title": "How do you want to provide additional evidence?"
-    }
-  },
   "question": {
     "textareaField": {
       "label": "Please enter your answer here",
@@ -724,10 +718,16 @@
     }
   },
   "additionalEvidence" : {
-    "evindenceOptions" : {},
-    "evindenceStatement" : {},
-    "evindenceUpload" : {},
-    "evindencePost" : {
+    "evidenceOptions" : {
+      "header": "How do you want to provide additional evidence?"
+    },
+    "evidenceStatement" : {
+      "header": "Write your statement"
+    },
+    "evidenceUpload" : {
+      "header": "Upload additional evidence"
+    },
+    "evidencePost" : {
        "header" : "Posting evidence to the tribunal",
        "subtitle": "Post evidence to the address below.",
        "description" : {

--- a/locale/en.json
+++ b/locale/en.json
@@ -64,6 +64,12 @@
       }
     }
   },
+  "additionalEvidence": {
+    "backToAppeal": "Back to Your benefit appeal",
+    "evidenceOptions": {
+      "title": "How do you want to provide additional evidence?"
+    }
+  },
   "question": {
     "textareaField": {
       "label": "Please enter your answer here",

--- a/locale/en.json
+++ b/locale/en.json
@@ -53,8 +53,9 @@
       "completed": "Completed"
     },
     "sendingEvidence": {
-      "header": "Sending additional evidence",
-      "intro": "You can provide additional information that’s relevant to your appeal. You don’t have to provide anything if you don’t have it.",
+      "header": "Providing additional evidence",
+      "intro": "If you have any additional information that is relevant to your appeal, you can",
+      "anchorText": "submit it to the tribunal.",
       "summary": "How to send additional evidence",
       "details": {
         "para1": "You can either email it or send it by post. Make sure it’s clearly marked with your appeal reference number:",

--- a/test/browser/1-task-list.test.ts
+++ b/test/browser/1-task-list.test.ts
@@ -80,11 +80,9 @@ describe('Task list page', () => {
     expect(displayedCaseRef).to.equal(caseReference);
   });
 
-  it('displays guidance for submitting evidence with case reference', async () => {
-    const summaryText = await taskListPage.getElementText('#sending-evidence-guide summary span');
-    const displayedCaseRef = await taskListPage.getElementText('#evidence-case-reference');
-    expect(summaryText.trim()).to.equal(i18n.taskList.sendingEvidence.summary);
-    expect(displayedCaseRef).to.equal(caseReference);
+  it('displays Providing additional evidence link', async () => {
+    const evidenceUploadLink = await taskListPage.getElementText('#evidence-options-link');
+    expect(evidenceUploadLink).to.equal(i18n.taskList.sendingEvidence.anchorText);
   });
 
   it('displays the deadline details as pending', async () => {

--- a/views/additional-evidence/evidence-options.html
+++ b/views/additional-evidence/evidence-options.html
@@ -1,44 +1,31 @@
 {% from "radios/macro.njk" import govukRadios %}
-{% extends "layout.html" %}
 
-{% block beforeContent %}
-  {{ super() }}
-  <a href="/task-list" class="govuk-back-link">{{ i18n.additionalEvidence.backToAppeal }}</a>
-{% endblock %}
-
-{% block corContent %}
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-l question-header">{{ i18n.additionalEvidence.evidenceOptions.title }}</h1>
-            <form>
-                    {{ govukRadios({
-                        idPrefix: "additional-evidence-option",
-                        name: "upload-option",
-                        fieldset: {
-                            legend: {
-                            text: i18n.additionalEvidence.evidenceOptions.title,
-                            isPageHeading: true,
-                            classes: "govuk-fieldset__legend--xl"
-                            }
-                        },
-                        items: [
-                            {
-                                value: "evidence-statement",
-                                text: "Write a statement online"
-                            },
-                            {
-                                value: "evidence-upload",
-                                text: "Upload letters, documents or photos"
-                            },
-                            {
-                                value: "evidence-post",
-                                text: "Send by post"
-                            }
-                        ]
-                        }) 
-                    }}
-                </form>
-        </div>
-    </div>
-    
-{% endblock %}}
+<h1 class="govuk-heading-l question-header">{{ i18n.additionalEvidence.evidenceOptions.header }}</h1>
+<form>
+        {{ govukRadios({
+            idPrefix: "additional-evidence-option",
+            name: "upload-option",
+            fieldset: {
+                legend: {
+                text: i18n.additionalEvidence.evidenceOptions.title,
+                isPageHeading: true,
+                classes: "govuk-fieldset__legend--xl"
+                }
+            },
+            items: [
+                {
+                    value: "evidence-statement",
+                    text: "Write a statement online"
+                },
+                {
+                    value: "evidence-upload",
+                    text: "Upload letters, documents or photos"
+                },
+                {
+                    value: "evidence-post",
+                    text: "Send by post"
+                }
+            ]
+            }) 
+        }}
+    </form>

--- a/views/additional-evidence/evidence-options.html
+++ b/views/additional-evidence/evidence-options.html
@@ -1,6 +1,44 @@
+{% from "radios/macro.njk" import govukRadios %}
 {% extends "layout.html" %}
 
+{% block beforeContent %}
+  {{ super() }}
+  <a href="/task-list" class="govuk-back-link">{{ i18n.additionalEvidence.backToAppeal }}</a>
+{% endblock %}
 
 {% block corContent %}
-    Additional Evidence
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l question-header">{{ i18n.additionalEvidence.evidenceOptions.title }}</h1>
+            <form>
+                    {{ govukRadios({
+                        idPrefix: "additional-evidence-option",
+                        name: "upload-option",
+                        fieldset: {
+                            legend: {
+                            text: i18n.additionalEvidence.evidenceOptions.title,
+                            isPageHeading: true,
+                            classes: "govuk-fieldset__legend--xl"
+                            }
+                        },
+                        items: [
+                            {
+                                value: "evidence-statement",
+                                text: "Write a statement online"
+                            },
+                            {
+                                value: "evidence-upload",
+                                text: "Upload letters, documents or photos"
+                            },
+                            {
+                                value: "evidence-post",
+                                text: "Send by post"
+                            }
+                        ]
+                        }) 
+                    }}
+                </form>
+        </div>
+    </div>
+    
 {% endblock %}}

--- a/views/additional-evidence/evidence-post.html
+++ b/views/additional-evidence/evidence-post.html
@@ -1,14 +1,14 @@
-<h1 class="govuk-heading-l">{{ i18n.additionalEvidence.evindencePost.header }}</h1>
+<h1 class="govuk-heading-l">{{ i18n.additionalEvidence.evidencePost.header }}</h1>
 
-<p>{{i18n.additionalEvidence.evindencePost.subtitle}}</p>
+<p>{{i18n.additionalEvidence.evidencePost.subtitle}}</p>
 <p >
     <address aria-label="{{ i18n.guidance.sendingEvidence.screenReaderPostalAddress }}">
         <span class="govuk-body govuk-!-font-weight-bold" aria-hidden="true">{{ i18n.guidance.sendingEvidence.postalAddress | safe }}</span>
     </address>
 </p>
-<p>{{i18n.additionalEvidence.evindencePost.description.para1 | eval | safe  }}</p>
-<p>{{i18n.additionalEvidence.evindencePost.description.para2  }}</p>
-<p>{{i18n.additionalEvidence.evindencePost.description.para3 | eval | safe}}</p>
+<p>{{i18n.additionalEvidence.evidencePost.description.para1 | eval | safe  }}</p>
+<p>{{i18n.additionalEvidence.evidencePost.description.para2  }}</p>
+<p>{{i18n.additionalEvidence.evidencePost.description.para3 | eval | safe}}</p>
 
 
 

--- a/views/additional-evidence/evidence-statement.html
+++ b/views/additional-evidence/evidence-statement.html
@@ -1,0 +1,1 @@
+<h1 class="govuk-heading-l question-header">{{ i18n.additionalEvidence.evidenceStatement.header }}</h1>

--- a/views/additional-evidence/evidence-upload.html
+++ b/views/additional-evidence/evidence-upload.html
@@ -1,0 +1,1 @@
+<h1 class="govuk-heading-l question-header">{{ i18n.additionalEvidence.evidenceUpload.header }}</h1>

--- a/views/additional-evidence/index.html
+++ b/views/additional-evidence/index.html
@@ -1,18 +1,18 @@
 {% extends "layout.html" %}
 
-{% if additionalEvidence.state === 'evidenceOptions' %}
-
-  {% set pageHeader = i18n.additionalEvidence.evidenceOptions.header %}
-
-{% elseif additionalEvidence.state === 'evidencePost' %}
+{% if action === 'options' %}
 
   {% set pageHeader = i18n.additionalEvidence.evidencePost.header %} 
 
-{% elseif additionalEvidence.state === 'evidenceUpload' %}
+{% elseif action === 'post' %}
+
+  {% set pageHeader = i18n.additionalEvidence.evidencePost.header %} 
+
+{% elseif action === 'upload' %}
 
   {% set pageHeader = i18n.additionalEvidence.evidenceUpload.header %}
 
-{% elseif additionalEvidence.state === 'evidenceStatement' %}
+{% elseif action === 'statement' %}
 
   {% set pageHeader = i18n.additionalEvidence.evidenceStatement.header %}
 
@@ -26,19 +26,19 @@
 {% block corContent %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% if additionalEvidence.state === 'evidenceOptions' %}
+      {% if action === 'options' %}
 
           {% include "additional-evidence/evidence-options.html" %}
 
-      {% elseif additionalEvidence.state === 'evidencePost' %}
+      {% elseif action === 'post' %}
 
           {% include "additional-evidence/evidence-post.html" %}
 
-      {% elseif additionalEvidence.state === 'evidenceUpload' %}
+      {% elseif action === 'upload' %}
 
           {% include "additional-evidence/evidence-upload.html" %}
 
-      {% elseif additionalEvidence.state === 'evidenceStatement' %}
+      {% elseif action === 'statement' %}
 
           {% include "additional-evidence/evidence-statement.html" %}
 

--- a/views/task-list.html
+++ b/views/task-list.html
@@ -58,23 +58,10 @@
         </div>
 
         <h2 class="govuk-heading-s">{{ i18n.taskList.sendingEvidence.header }}</h2>
-        <p>{{ i18n.taskList.sendingEvidence.intro }}</p>
-
-        <details id="sending-evidence-guide" class="govuk-details">
-            <summary class="govuk-details__summary">
-                <span class="govuk-details__summary-text">
-                  {{ i18n.taskList.sendingEvidence.summary }}
-                </span>
-            </summary>
-            <div class="govuk-details__text">
-                <p>{{ i18n.taskList.sendingEvidence.details.para1 }} <strong id="evidence-case-reference">{{ hearing.case_reference }}</strong></p>
-
-                {% include "includes/sending-evidence-contact-details.html" %}
-
-                <p>{{ i18n.taskList.sendingEvidence.details.closingPara1 }}</p>
-                <p>{{ i18n.taskList.sendingEvidence.details.closingPara2 }}</p>
-            </div>
-        </details>
+        <p>
+            {{ i18n.taskList.sendingEvidence.intro }} 
+            <a id="evidence-options-link" href="/evidence-options">{{ i18n.taskList.sendingEvidence.anchorText }}</a>
+        </p>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-3565

### Change description ###
Adding option to provide additional evidence on task-list page.

A link should redirect the appellant to a page with different options to send new evidence.
Evidence options are: 
- Write a statement online
- Upload a document
- Provide information to the appellant so he or she can send the evidence through the post 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
