### PR TITLE
SSCS-6062 Load the appeal when assigning a case to a user

### DIFF
--- a/app/server/routes.ts
+++ b/app/server/routes.ts
@@ -48,7 +48,7 @@ const idamService: IdamService = new IdamService(idamApiUrl, appPort, appSecret)
 const hearingService: HearingService = new HearingService(apiUrl);
 const questionService: QuestionService = new QuestionService(apiUrl);
 const additionalEvidenceService: AdditionalEvidenceService = new AdditionalEvidenceService(apiUrl);
-const trackYourApealService: TrackYourApealService = new TrackYourApealService(tribunalsApiUrl);
+const trackYourAppealService: TrackYourApealService = new TrackYourApealService(tribunalsApiUrl);
 
 const prereqMiddleware = [ensureAuthenticated, checkDecision];
 
@@ -63,7 +63,7 @@ const tribunalViewController = setupTribunalViewController({ prereqMiddleware: e
 const tribunalViewAcceptedController = setupTribunalViewAcceptedController({ prereqMiddleware: ensureAuthenticated });
 const hearingConfirmController = setupHearingConfirmController({ prereqMiddleware: ensureAuthenticated });
 const hearingWhyController = setupHearingWhyController({ prereqMiddleware: ensureAuthenticated, hearingService });
-const loginController = setupLoginController({ hearingService, idamService, trackYourApealService });
+const loginController = setupLoginController({ hearingService, idamService, trackYourApealService: trackYourAppealService });
 const idamStubController = setupIdamStubController();
 const cookiePrivacyController = setupCookiePrivacyController();
 const sessionController = setupSessionController({ prereqMiddleware: ensureAuthenticated });
@@ -71,7 +71,7 @@ const evidenceOptionsController = setupadditionalEvidenceController({ prereqMidd
 const statusController = setupStatusController({ prereqMiddleware: ensureAuthenticated });
 const yourDetailsController = setupYourDetailsController({ prereqMiddleware: ensureAuthenticated });
 const historyController = setupHistoryController({ prereqMiddleware: ensureAuthenticated });
-const assignCaseController = setupAssignCaseController({ hearingService });
+const assignCaseController = setupAssignCaseController({ hearingService, trackYourApealService: trackYourAppealService });
 const hearingTabController = setupHearingController({ prereqMiddleware: ensureAuthenticated });
 
 router.use((req, res, next) => {


### PR DESCRIPTION
Previosly we were not loaidng the appeal when a case was assigned to a
user instead we were getting an error. Load the appeal after assigning
the case in the same way we do when we login and we have already
assigned the appeal.

https://tools.hmcts.net/jira/browse/SSCS-6062

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
