### PR TITLE
SSCS-6134 Load MYA even if an SC number has been set

### DIFF
--- a/app/server/utils/screenReaderUtils.ts
+++ b/app/server/utils/screenReaderUtils.ts
@@ -1,5 +1,8 @@
 function spellNumbersOut(word: string) {
-  return word.replace(/(\s){1,}/g, '.').split('').join(' ').replace(/ [\/\.]/g, '.');
+  if (word) {
+    return word.replace(/(\s){1,}/g, '.').split('').join(' ').replace(/ [\/\.]/g, '.');
+  }
+  return word;
 }
 
 export { spellNumbersOut };

--- a/locale/en.json
+++ b/locale/en.json
@@ -576,7 +576,7 @@
       "header": "A hearing needs to be booked for your appeal",
       "para1": "You'll receive an email with the details of your hearing by {{ responseDate }}.",
       "para2": "If you require a hearing room with disabled access or any other support then please email the tribunal at ",
-      "para3": "Include your appeal reference number on any emails to the tribunal:", 
+      "para3": "Include your appeal reference number on any emails to the tribunal:",
       "exitLink": "https://www.smartsurvey.co.uk/s/JETIK/"
     }
   },
@@ -610,7 +610,8 @@
     "delete": "Delete",
     "serviceTitle": "Appeal a benefit decision",
     "govUK": "GOV.UK",
-    "exitLink" : "https://www.smartsurvey.co.uk/s/D2NIM/?pageurl="
+    "exitLink" : "https://www.smartsurvey.co.uk/s/D2NIM/?pageurl=",
+    "tbc" : "To be confirmed"
   },
   "errorSummary": {
     "titleText": "There are errors on the page",
@@ -795,7 +796,7 @@
         "types": {
             "medical": {
               "header": "Medical evidence",
-              "para1": "This type of evidence helps the tribunal understand your condition from the perspective of a medical professional. For example, letters you have from your hospital consultant, doctor, physiotherapist or social worker. A useful letter explains how your condition affects your life at the time of the decision by DWP. Appointment letters are not useful.", 
+              "para1": "This type of evidence helps the tribunal understand your condition from the perspective of a medical professional. For example, letters you have from your hospital consultant, doctor, physiotherapist or social worker. A useful letter explains how your condition affects your life at the time of the decision by DWP. Appointment letters are not useful.",
               "para2": "If you don’t have any letters and you think one will help your appeal, you could ask the medical professional who has been treating your condition to write one. Please be aware they may charge you for this and they can take a long time to organise. The tribunal can’t pay for these."
             },
             "statement": {

--- a/test/unit/utils/screenReaderUtils.ts
+++ b/test/unit/utils/screenReaderUtils.ts
@@ -9,4 +9,9 @@ describe('#screenReaderUtils', () => {
   it('should spell out a long number', () => {
     expect(spellNumbersOut('0782  922 300')).to.equal('0 7 8 2. 9 2 2. 3 0 0');
   });
+
+  it('should handled undefined name', () => {
+    const word = undefined;
+    expect(spellNumbersOut(word)).to.equal(word);
+  });
 });

--- a/views/includes/appellant-details.html
+++ b/views/includes/appellant-details.html
@@ -2,5 +2,5 @@
     <h2 class="govuk-heading-m">
         <span id="appellant-name">{{ hearing.appellant_name }}</span>
     </h2>
-    <p tabindex="0">Appeal reference: <span id="case-reference" aria-label="{{ screenReaderUtils.spellNumbersOut(hearing.case_reference) }}">{{ hearing.case_reference }}</span></p>
+    <p tabindex="0">Appeal reference: <span id="case-reference" aria-label="{{ screenReaderUtils.spellNumbersOut(hearing.case_reference) | default(i18n.general.tbc) }}">{{ hearing.case_reference | default(i18n.general.tbc) }}</span></p>
 </div>


### PR DESCRIPTION
Currently MYA fails with an error if the case does not have an SC
number. This is an edge case as the appellant should not have got a link
to MYA until their case has an SC number but sometimes we will send one
out. The only issue was we spell out the sc number for screen readers
so made that function handle undefined and display 'to be confirmed' on
the page.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-6134

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
