### PR TITLE
SSCS-6098 Update get coversheet endpoint

### DIFF
--- a/app/server/controllers/task-list.ts
+++ b/app/server/controllers/task-list.ts
@@ -67,8 +67,8 @@ function getCoversheet(additionalEvidenceService: AdditionalEvidenceService) {
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
       if (!isFeatureEnabled(Feature.ADDITIONAL_EVIDENCE_FEATURE, req.cookies)) {
-        const hearingId = req.session.hearing.online_hearing_id;
-        const coversheet = await additionalEvidenceService.getCoversheet(hearingId, req);
+        const caseId = req.session.hearing.case_id;
+        const coversheet = await additionalEvidenceService.getCoversheet(caseId, req);
         res.header('content-type', 'application/pdf');
         res.send(new Buffer(coversheet, 'binary'));
       } else {

--- a/app/server/services/additional-evidence.ts
+++ b/app/server/services/additional-evidence.ts
@@ -59,11 +59,11 @@ export class AdditionalEvidenceService {
     }, req);
   }
 
-  async getCoversheet(hearingId: string, req: Request) {
+  async getCoversheet(caseId: string, req: Request) {
     return RequestPromise.request({
       method: 'GET',
       encoding: 'binary',
-      uri: `${this.apiUrl}/continuous-online-hearings/${hearingId}/evidence/coversheet`,
+      uri: `${this.apiUrl}/continuous-online-hearings/${caseId}/evidence/coversheet`,
       headers: {
         'Content-type': 'applcation/pdf'
       }

--- a/test/unit/controllers/task-list.test.ts
+++ b/test/unit/controllers/task-list.test.ts
@@ -23,7 +23,8 @@ describe('controllers/task-list', () => {
   const hearingDetails = {
     online_hearing_id: '1',
     case_reference: 'SC/123/456',
-    appellant_name: 'John Smith'
+    appellant_name: 'John Smith',
+    case_id: 123456
   };
 
   beforeEach(() => {


### PR DESCRIPTION
Previously you had to have a hearing id to get a cover sheet. Now with
MYA you might not have a hearing ID. so need to create the coversheet
with the case id. Update the coversheet endpoint to take either a case
id or hearing id. As the case id is a long and the hearing id a GUUID
we can tell which we have been given.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-6098

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
