### PR TITLE
Suppress hearing tab for appellants in COR

### DIFF
--- a/app/server/controllers/hearing.ts
+++ b/app/server/controllers/hearing.ts
@@ -3,7 +3,7 @@ import * as Paths from '../paths';
 import { isFeatureEnabled, Feature } from '../utils/featureEnabled';
 
 function getHearing(req: Request, res: Response) {
-  if (!isFeatureEnabled(Feature.MANAGE_YOUR_APPEAL, req.cookies)) return res.render('errors/404.html');
+  if (!isFeatureEnabled(Feature.MANAGE_YOUR_APPEAL, req.cookies) || req.session.appeal.hearingType === 'cor') return res.render('errors/404.html');
   const { latestEvents = [], historicalEvents = [], hearingType } = req.session.appeal;
   const attending: boolean = hearingType === 'oral';
   const hearingInfo = latestEvents.concat(historicalEvents).find(event => {

--- a/app/server/middleware/ensure-authenticated.ts
+++ b/app/server/middleware/ensure-authenticated.ts
@@ -28,35 +28,43 @@ function setLocals(req, res, next) {
   res.locals.featureFlags = {};
   res.locals.featureFlags[Feature.MANAGE_YOUR_APPEAL] = isFeatureEnabled(Feature.MANAGE_YOUR_APPEAL, req.cookies);
   res.locals.featureFlags[Feature.ADDITIONAL_EVIDENCE_FEATURE] = isFeatureEnabled(Feature.ADDITIONAL_EVIDENCE_FEATURE, req.cookies);
+
+  // Setting up Tabs to show on MYA;
+  if (isFeatureEnabled(Feature.MANAGE_YOUR_APPEAL, req.cookies)) {
+    res.locals.tabs = setTabNavigationItems(req.session.appeal);
+  }
   next();
 }
 
-function setTabNavigationItems(req, res, next) {
-  // TODO: req.session contains appeal or hearing, show/hide tabs accordingly
-  const tabs = {
-    'status': {
+function setTabNavigationItems(appeal) {
+  const { hearingType } = appeal;
+  const tabs = [
+    {
+      'id': 'status',
       'title': 'Status',
       'url': '/status'
     },
-    'questions': {
+    {
+      'id': 'questions',
       'title': 'Provide Evidence',
       'url': '/task-list'
     },
-    'hearing': {
+    {
+      'id': 'hearing',
       'title': 'Hearing',
       'url': '/hearing'
     },
-    'history': {
+    {
+      'id': 'history',
       'title': 'History',
       'url': '/history'
     }
-  };
-
-  Object.assign(res.locals, { tabs });
-  next();
+  ];
+  const tabsToShow = hearingType === 'cor' ? tabs.filter(tab => tab.title !== 'Hearing') : tabs;
+  return tabsToShow;
 }
 
-const ensureAuthenticated = [checkAccessToken, setLocals, setTabNavigationItems];
+const ensureAuthenticated = [checkAccessToken, setLocals];
 
 export {
   checkAccessToken,

--- a/test/unit/middleware/ensure-authenticated.test.ts
+++ b/test/unit/middleware/ensure-authenticated.test.ts
@@ -19,7 +19,8 @@ describe('middleware/ensure-authenticated', () => {
         id: '123',
         hearing: hearingDetails,
         destroy: sinon.stub().yields()
-      }
+      },
+      cookie: {}
     };
     res = {
       redirect: sinon.spy(),
@@ -55,7 +56,19 @@ describe('middleware/ensure-authenticated', () => {
     it('sets hearing data on the locals', () => {
       setLocals(req, res, next);
       expect(res.locals).to.have.property('hearing');
+      expect(res.locals).to.not.have.property('tabs');
       expect(res.locals.hearing).to.deep.equal(hearingDetails);
+    });
+    it('also sets tabs data on the locals', () => {
+      req.cookies = {
+        manageYourAppeal: 'true'
+      };
+      req.session['appeal'] = {
+        hearingType: 'cor'
+      };
+
+      setLocals(req, res, next);
+      expect(res.locals).to.have.property('tabs');
     });
     it('sets showSignOut on the locals', () => {
       setLocals(req, res, next);
@@ -67,7 +80,7 @@ describe('middleware/ensure-authenticated', () => {
     it('is an array of middleware functions', () => {
       expect(ensureAuthenticated).to.be.an('array');
       /* eslint-disable-next-line no-magic-numbers */
-      expect(ensureAuthenticated).to.have.lengthOf(3);
+      expect(ensureAuthenticated).to.have.lengthOf(2);
     });
   });
 });

--- a/test/unit/routes.test.ts
+++ b/test/unit/routes.test.ts
@@ -68,6 +68,9 @@ describe('Routes', () => {
             case_reference: 'SC/112/233',
             online_hearing_id: '2-completed'
           };
+          req.session.appeal = {
+            hearingType: 'cor'
+          };
           req.session.questions = [
             {
               question_id: '001',
@@ -149,6 +152,9 @@ describe('Routes', () => {
             final_decision: { reason: 'final decision reason' },
             has_final_decision: true
           };
+          req.session.appeal = {
+            hearingType: 'cor'
+          };
           next();
         });
         mockApp.use(app);
@@ -183,6 +189,9 @@ describe('Routes', () => {
           };
           req.session.accessToken = 'mock uid';
           req.session.hearing = hearingDetails,
+          req.session.appeal = {
+            hearingType: 'cor'
+          };
           next();
         });
         mockApp.use(app);

--- a/views/components/navigation-tabs.html
+++ b/views/components/navigation-tabs.html
@@ -1,8 +1,8 @@
 {% macro navigationTabs(active) %}
     <nav class="navigation-tabs">
         <ul class="navigation-tabs__list">
-            {% for key, tab in tabs %}
-                <li class="{{ 'selected' if key == active }}">
+            {% for tab in tabs %}
+                <li class="{{ 'selected' if tab.id == active }}">
                     <a href="{{ tab.url }}">{{ tab.title }}</a>
                 </li>
             {% endfor %}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-6259


### Change description ###
Appellants in COR shouldn't be able to see Hearing Tab or even enter the page if they enter the url directly.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
