### PR TITLE
Adding back signout for non MYA

### DIFF
--- a/app/client/sass/application.scss
+++ b/app/client/sass/application.scss
@@ -106,6 +106,12 @@ ol {
   }
 }
 
+.govuk-header__link--signout {	
+  margin-top:5px;	
+  float:right;	
+  font-weight:700;	
+}
+
 .govuk-header__link--service-name {
   font-size: 21px;
   margin-top: 1px;

--- a/test/browser/1-task-list.test.ts
+++ b/test/browser/1-task-list.test.ts
@@ -107,7 +107,7 @@ describe('Task list page', () => {
   });
 
   it('signs out and prevents access to pages', async () => {
-    await page.goto(`${testUrl}${Paths.logout}`);
+    await taskListPage.signOut();
     loginPage.verifyPage();
     await taskListPage.visitPage();
     loginPage.verifyPage();

--- a/test/browser/6-mya.test.ts
+++ b/test/browser/6-mya.test.ts
@@ -43,4 +43,10 @@ describe('Manage your appeal app @mya', () => {
 
     statusPage.verifyPage();
   });
+  it('signs out and prevents access to pages', async () => {
+    await statusPage.signOut();
+    loginPage.verifyPage();
+    await statusPage.visitPage();
+    loginPage.verifyPage();
+  });
 });

--- a/test/page-objects/base.ts
+++ b/test/page-objects/base.ts
@@ -144,6 +144,7 @@ export class BasePage {
   async signOut() {
     const [ cookies ] = await this.page.cookies();
     let signOutSelector = '.govuk-header__link--signout';
+    console.log('cookies', cookies, 'signOutSelector', signOutSelector);
     if (
       (cookies.name === 'manageYourAppeal' &&
       cookies.value === 'true') || myaFeature === 'true'

--- a/test/page-objects/base.ts
+++ b/test/page-objects/base.ts
@@ -3,6 +3,7 @@ const config = require('config');
 
 const testUrl = config.get('testUrl');
 const navigationTimeout = config.get('navigationTimeout');
+const myaFeature = config.get('featureFlags.manageYourAppeal');
 export class BasePage {
 
   public page: any;
@@ -141,9 +142,15 @@ export class BasePage {
   }
 
   async signOut() {
+    const [ cookies ] = await this.page.cookies();
+    let signOutSelector = '.govuk-header__link--signout';
+    if (
+      (cookies.name === 'manageYourAppeal' &&
+      cookies.value === 'true') || myaFeature === 'true'
+    ) signOutSelector = '.account-navigation__links .sign-out';
     await Promise.all([
       this.page.waitForNavigation(),
-      this.clickElement('.account-navigation__links .sign-out')
+      this.clickElement(signOutSelector)
     ]);
   }
 

--- a/test/page-objects/base.ts
+++ b/test/page-objects/base.ts
@@ -142,13 +142,19 @@ export class BasePage {
   }
 
   async signOut() {
-    const [ cookies ] = await this.page.cookies();
+    const cookies = await this.page.cookies();
+    const myaFeature = cookies.reduce((acc, cookie) => {
+      if (cookie.name === 'manageYourAppeal' && cookie.value === 'true') {
+        return true;
+      }
+      return acc;
+    }, false);
     let signOutSelector = '.govuk-header__link--signout';
-    console.log('cookies', cookies, 'signOutSelector', signOutSelector);
     if (
       (cookies.name === 'manageYourAppeal' &&
-      cookies.value === 'true') || myaFeature === 'true'
+      cookies.value === 'true') || myaFeature
     ) signOutSelector = '.account-navigation__links .sign-out';
+
     await Promise.all([
       this.page.waitForNavigation(),
       this.clickElement(signOutSelector)

--- a/views/includes/header.html
+++ b/views/includes/header.html
@@ -9,6 +9,11 @@
             <a href="/" class="govuk-header__link govuk-header__link--service-name">
                 {{ i18n.general.serviceTitle }}
             </a>
+            {% if showSignOut and not featureFlags.manageYourAppeal %}	
+                <a class="govuk-header__link govuk-header__link--signout" href="/sign-out">	
+                    {{ i18n.general.signOut }}	
+                </a>	
+            {% endif %}
         </div>
     </div>
 </header>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-6298


### Change description ###
Signout link was reallocated from header to a new navigation bar only visible if MYA feature is active. Old signout link was removed from the original header and so appellants cant currently sign out. This PR fixes that and adds back the link so users are able to sign out.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
