### PR TITLE
SSCS-7170 Fix file input keyboard discovery/focus

### DIFF
--- a/app/client/javascript/evidence-upload.ts
+++ b/app/client/javascript/evidence-upload.ts
@@ -73,7 +73,7 @@ export class EvidenceUpload {
   }
 
   setFileUploadState(): void {
-    document.getElementById(this.FILE_UPLOAD_ID).style.display = 'none';
+    document.getElementById(this.FILE_UPLOAD_ID).className = 'file-display-none';
     const fileUploadLabel: HTMLElement = document.querySelector(this.FILE_UPLOAD_LABEL_SELECTOR);
     fileUploadLabel.style.display = '';
     fileUploadLabel.className = 'govuk-button secondary-button';

--- a/app/client/sass/_question.scss
+++ b/app/client/sass/_question.scss
@@ -48,6 +48,14 @@ table#files-uploaded {
   #file-upload-1-error {
     margin-top: 15px;
   }
+  .file-display-none {
+    z-index: -1;
+    position: relative;
+    width: 116px;
+    height: 40px;
+    top: -36px;
+  }
+
 }
 
 #upload-spinner{

--- a/app/client/sass/application.scss
+++ b/app/client/sass/application.scss
@@ -145,6 +145,15 @@ address {
   display: inline-block;
 }
 
+.file-display-none {
+  z-index: -1;
+  position: relative;
+  width: 116px;
+  height: 43px;
+  top: -48px;
+  margin-bottom: -40px;
+}
+
 .display--none {
   display: none;
 }

--- a/test/unit/client/evidence-upload.test.ts
+++ b/test/unit/client/evidence-upload.test.ts
@@ -85,7 +85,7 @@ describe('evidence-upload', () => {
     it('sets file upload state', () => {
       const fileUpload: HTMLElement = document.getElementById(evidenceUpload.FILE_UPLOAD_ID);
       const fileUploadLabel: HTMLElement = body.querySelector(evidenceUpload.FILE_UPLOAD_LABEL_SELECTOR);
-      expect(fileUpload.style.display).to.equal('none');
+      expect(fileUpload.className).to.equal('file-display-none');
       expect(fileUploadLabel.style.display).to.equal('');
       expect(fileUploadLabel.className).to.equal('govuk-button secondary-button');
     });

--- a/views/additional-evidence/evidence-upload.html
+++ b/views/additional-evidence/evidence-upload.html
@@ -28,7 +28,7 @@
         {{ govukFileUpload({
             id: "additional-evidence-file",
             name: "additional-evidence-file",
-            classes: "display--none",
+            classes: "file-display-none",
             label: {
                 text: i18n.questionUploadEvidence.label,
                 classes: "govuk-button secondary-button element--inline-block",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-7170


### Change description ###
Amending file upload inputs to be included in the tab order
* this ensures that they are keyboard discoverable, but the appearance remains the same
* instead of not displaying the file input, it is made the same size and location as the label and hidden behind it using a z-index



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
