### PR TITLE
SSCS-9799 - confirmation after requesting a hearing recording

### DIFF
--- a/views/request-type/index.html
+++ b/views/request-type/index.html
@@ -26,6 +26,9 @@
     <div class="govuk-grid-column-two-thirds">
         {{ navigationTabs("requestType") }}
         <div class="task-list">
+            {% if action === "confirm" %}
+                {% include "request-type/request-confirm.html" %}
+            {% endif %}
             <h2 class="govuk-heading-m --margin-bottom-s">{{ content[i18n.language].requestTypeTab.selectRequestHeader | safe }}</h2>
             <form class="--padding-top-m" id="request-option-form" name="request-option-form" action="/request-type/select?_csrf={{csrfToken}}" method="POST">
                 <div>
@@ -53,8 +56,6 @@
 
         {% if action === "hearingRecording" %}
             {% include "request-type/hearing-recording.html" %}
-        {% elseif action === "confirm" %}
-            {% include "request-type/request-confirm.html" %}
         {% endif %}
 
         </div>

--- a/views/request-type/request-confirm.html
+++ b/views/request-type/request-confirm.html
@@ -1,3 +1,3 @@
 <div class="govuk-grid-column-full">
-    <p>{{ content[i18n.language].hearingRecording.requestConfirmed | safe }}</p>
+    <p style="color:#00703c">{{ content[i18n.language].hearingRecording.requestConfirmed | safe }}</p>
 </div>


### PR DESCRIPTION
SSCS-9799 - confirmation after requesting a hearing recording

Success Message (moved text up and made it green):

<img width="1032" alt="success message when submitted" src="https://user-images.githubusercontent.com/369407/141984733-73dbafe7-e91f-4c60-aa01-8970a7367576.png">

Error Message (when tribunals is down is as before):

<img width="1023" alt="error when tribunals is down" src="https://user-images.githubusercontent.com/369407/141984746-93ece3fa-9ca3-4d0a-bb65-1227d8e09b55.png">

